### PR TITLE
bug: forward Badge ref to fix React ref warning

### DIFF
--- a/client/src/components/ui/badge.tsx
+++ b/client/src/components/ui/badge.tsx
@@ -1,5 +1,5 @@
 import { cva, type VariantProps } from "class-variance-authority";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -27,8 +27,17 @@ export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
-}
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(badgeVariants({ variant }), className)}
+        {...props}
+      />
+    );
+  },
+);
+Badge.displayName = "Badge";
 
 export { Badge, badgeVariants };


### PR DESCRIPTION
### Motivation
- Tests were producing React console warnings: "Function components cannot be given refs" when Radix `Slot` tried to pass a ref to `Badge`.
- The `Badge` component did not accept forwarded refs, which caused noisy test output and potential runtime issues with Radix primitives.

### Description
- Change the React import to `import * as React from "react"` and wrap `Badge` with `React.forwardRef<HTMLDivElement, BadgeProps>`.
- Forward the `ref` to the root `<div>` and add `Badge.displayName = "Badge"` for clearer debugging and compatibility with Radix.
- Kept the existing `BadgeProps` and exports (`Badge` and `badgeVariants`) unchanged to preserve public API.

### Testing
- Ran `npm test` (Vitest) as required by project guidelines.
- The test suite completed successfully with all automated tests passing: `19 tests passed (19)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694698a4270c83239bbb82217ae8274c)