### PR TITLE
chore: refine keyboard interactions and accessibility in transcript components

### DIFF
--- a/client/src/components/SpeakerSidebar.tsx
+++ b/client/src/components/SpeakerSidebar.tsx
@@ -84,6 +84,16 @@ export function SpeakerSidebar({
     }
   };
 
+  const handleSpeakerKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+    speakerName: string,
+  ) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onSpeakerSelect?.(speakerName);
+    }
+  };
+
   return (
     <div className="flex flex-col h-full">
       <div className="p-4 border-b">
@@ -115,7 +125,11 @@ export function SpeakerSidebar({
                 selectedSpeaker === speaker.name && "bg-accent",
               )}
               onClick={() => onSpeakerSelect?.(speaker.name)}
+              onKeyDown={(event) => handleSpeakerKeyDown(event, speaker.name)}
               data-testid={`speaker-card-${speaker.id}`}
+              role="button"
+              tabIndex={0}
+              aria-pressed={selectedSpeaker === speaker.name}
             >
               <div
                 className="w-1 h-10 rounded-full flex-shrink-0"

--- a/client/src/components/TranscriptSegment.tsx
+++ b/client/src/components/TranscriptSegment.tsx
@@ -92,6 +92,16 @@ export function TranscriptSegment({
     [onSeek],
   );
 
+  const handleSelectKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        onSelect();
+      }
+    },
+    [onSelect],
+  );
+
   const getActiveWordIndex = useCallback(() => {
     if (!isActive) return -1;
     return segment.words.findIndex((w) => currentTime >= w.start && currentTime <= w.end);
@@ -108,10 +118,12 @@ export function TranscriptSegment({
         !isSelected && !isActive && "hover-elevate",
       )}
       onClick={onSelect}
+      onKeyDown={handleSelectKeyDown}
       data-testid={`segment-${segment.id}`}
       data-segment-id={segment.id}
       role="article"
       aria-label={`Segment by ${segment.speaker}`}
+      tabIndex={0}
     >
       <div className="flex items-start gap-3">
         <div className="w-1 self-stretch rounded-full" style={{ backgroundColor: speakerColor }} />
@@ -168,6 +180,8 @@ export function TranscriptSegment({
               isEditing && "bg-background rounded px-2 py-1 ring-1 ring-ring",
             )}
             data-testid={`text-segment-${segment.id}`}
+            role="textbox"
+            aria-readonly={!isEditing}
           >
             {!isEditing
               ? segment.words.map((word, index) => (

--- a/client/src/components/__tests__/SpeakerSidebar.test.tsx
+++ b/client/src/components/__tests__/SpeakerSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { SpeakerSidebar } from "@/components/SpeakerSidebar";
@@ -90,7 +90,8 @@ describe("SpeakerSidebar", () => {
       />,
     );
 
-    await userEvent.click(screen.getByText("SPEAKER_00"));
+    const speakerCard = screen.getByTestId("speaker-card-s1");
+    fireEvent.keyDown(speakerCard, { key: "Enter" });
     expect(onSpeakerSelect).toHaveBeenCalledWith("SPEAKER_00");
 
     await userEvent.click(screen.getByTestId("button-clear-speaker-filter"));

--- a/client/src/components/__tests__/TranscriptEditor.test.tsx
+++ b/client/src/components/__tests__/TranscriptEditor.test.tsx
@@ -12,7 +12,11 @@ vi.mock("react-hotkeys-hook", () => ({
 
 vi.mock("@/components/FileUpload", () => ({
   FileUpload: ({ onTranscriptUpload }: { onTranscriptUpload: (data: unknown) => void }) => (
-    <button data-testid="mock-upload" onClick={() => onTranscriptUpload(mockTranscriptData)}>
+    <button
+      type="button"
+      data-testid="mock-upload"
+      onClick={() => onTranscriptUpload(mockTranscriptData)}
+    >
       Upload
     </button>
   ),

--- a/client/src/components/__tests__/TranscriptSegment.test.tsx
+++ b/client/src/components/__tests__/TranscriptSegment.test.tsx
@@ -24,6 +24,7 @@ const segment: Segment = {
 describe("TranscriptSegment", () => {
   it("renders word tokens and seeks on click", async () => {
     const onSeek = vi.fn();
+    const onSelect = vi.fn();
     render(
       <TranscriptSegment
         segment={segment}
@@ -31,7 +32,7 @@ describe("TranscriptSegment", () => {
         isSelected={false}
         isActive={false}
         currentTime={0}
-        onSelect={vi.fn()}
+        onSelect={onSelect}
         onTextChange={vi.fn()}
         onSpeakerChange={vi.fn()}
         onSplit={vi.fn()}
@@ -40,9 +41,12 @@ describe("TranscriptSegment", () => {
       />,
     );
 
+    const segmentCard = screen.getByTestId("segment-seg-1");
+    fireEvent.keyDown(segmentCard, { key: "Enter" });
     const word = screen.getByTestId("word-seg-1-0");
     await userEvent.click(word);
 
+    expect(onSelect).toHaveBeenCalled();
     expect(onSeek).toHaveBeenCalledWith(0);
     expect(screen.getByText("Hallo")).toBeInTheDocument();
     expect(screen.getByText("Welt")).toBeInTheDocument();


### PR DESCRIPTION
### Motivation
- Resolve a set of uncritical `biome` lint/a11y findings by making interactive transcript UI elements keyboard-accessible.
- Improve accessibility of transcript text blocks and speaker cards so keyboard-only users can activate them.
- Make small test adjustments to ensure mocks behave like real buttons and to cover the new keyboard flows.
- Keep changes minimal-impact and focused on behavior and tests without refactoring component internals.

### Description
- Added keyboard handlers and activation support for speaker cards via `handleSpeakerKeyDown`, `role="button"`, `tabIndex={0}`, and `aria-pressed` in `SpeakerSidebar.tsx`.
- Added keyboard activation for transcript segment containers via `handleSelectKeyDown` and `tabIndex={0}`, and annotated the editable text block with `role="textbox"` and `aria-readonly` in `TranscriptSegment.tsx`.
- Updated component tests to cover keyboard interactions and button semantics by adding `type="button"` to the mocked upload button and simulating `keyDown` events with `fireEvent` in tests for `SpeakerSidebar` and `TranscriptSegment`.
- Small test import changes to include `fireEvent` and wired an `onSelect` mock to assert keyboard activation.

### Testing
- Ran the test suite with `npm test` and all tests passed: 4 test files, 19 tests passed.
- Also executed `npm test -- --coverage` during verification to confirm tests run under coverage tooling; tests completed successfully (coverage reported by v8).
- Component tests were extended and exercised the new keyboard flows and the mocked upload button behavior.
- No automated tests failed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69469a66ec8c8323acbeaf0fb03971fd)