### PR TITLE
chore: fix biome accessibility lint warnings

### DIFF
--- a/client/src/components/TranscriptSegment.tsx
+++ b/client/src/components/TranscriptSegment.tsx
@@ -80,16 +80,34 @@ export function TranscriptSegment({
     [handleBlur, segment.text],
   );
 
-  const handleWordClick = useCallback(
-    (word: Word, index: number, e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (e.shiftKey) {
+  const handleWordAction = useCallback(
+    (word: Word, index: number, shiftKey: boolean) => {
+      if (shiftKey) {
         setSelectedWordIndex(index);
       } else {
         onSeek(word.start);
       }
     },
     [onSeek],
+  );
+
+  const handleWordClick = useCallback(
+    (word: Word, index: number, e: React.MouseEvent) => {
+      e.stopPropagation();
+      handleWordAction(word, index, e.shiftKey);
+    },
+    [handleWordAction],
+  );
+
+  const handleWordKeyDown = useCallback(
+    (word: Word, index: number, event: React.KeyboardEvent<HTMLSpanElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        event.stopPropagation();
+        handleWordAction(word, index, event.shiftKey);
+      }
+    },
+    [handleWordAction],
   );
 
   const handleSelectKeyDown = useCallback(
@@ -121,8 +139,9 @@ export function TranscriptSegment({
       onKeyDown={handleSelectKeyDown}
       data-testid={`segment-${segment.id}`}
       data-segment-id={segment.id}
-      role="article"
+      role="button"
       aria-label={`Segment by ${segment.speaker}`}
+      aria-pressed={isSelected}
       tabIndex={0}
     >
       <div className="flex items-start gap-3">
@@ -182,18 +201,22 @@ export function TranscriptSegment({
             data-testid={`text-segment-${segment.id}`}
             role="textbox"
             aria-readonly={!isEditing}
+            tabIndex={0}
           >
             {!isEditing
               ? segment.words.map((word, index) => (
                   <span
                     key={`${segment.id}-${word.start}-${word.end}`}
                     onClick={(e) => handleWordClick(word, index, e)}
+                    onKeyDown={(event) => handleWordKeyDown(word, index, event)}
                     className={cn(
                       "cursor-pointer transition-colors",
                       index === activeWordIndex && "bg-primary/20 underline",
                       index === selectedWordIndex && "bg-accent ring-1 ring-ring",
                     )}
                     data-testid={`word-${segment.id}-${index}`}
+                    role="button"
+                    tabIndex={0}
                   >
                     {word.word}{" "}
                   </span>

--- a/client/src/components/__tests__/TranscriptSegment.test.tsx
+++ b/client/src/components/__tests__/TranscriptSegment.test.tsx
@@ -107,4 +107,90 @@ describe("TranscriptSegment", () => {
 
     expect(onTextChange).toHaveBeenCalledWith("Hallo zusammen");
   });
+
+  it("saves edited text on Enter and cancels on Escape", () => {
+    const onTextChange = vi.fn();
+    render(
+      <TranscriptSegment
+        segment={segment}
+        speakers={speakers}
+        isSelected={false}
+        isActive={false}
+        currentTime={0}
+        onSelect={vi.fn()}
+        onTextChange={onTextChange}
+        onSpeakerChange={vi.fn()}
+        onSplit={vi.fn()}
+        onDelete={vi.fn()}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    const textBlock = screen.getByTestId("text-segment-seg-1");
+    fireEvent.doubleClick(textBlock);
+    Object.defineProperty(textBlock, "innerText", {
+      value: "Hallo zusammen",
+      writable: true,
+    });
+    fireEvent.keyDown(textBlock, { key: "Enter" });
+
+    expect(onTextChange).toHaveBeenCalledWith("Hallo zusammen");
+
+    fireEvent.doubleClick(textBlock);
+    Object.defineProperty(textBlock, "innerText", {
+      value: "Andere Worte",
+      writable: true,
+    });
+    fireEvent.keyDown(textBlock, { key: "Escape" });
+
+    expect(onTextChange).toHaveBeenCalledTimes(1);
+    expect(textBlock).toHaveTextContent(segment.text);
+  });
+
+  it("seeks when activating word with keyboard", () => {
+    const onSeek = vi.fn();
+    render(
+      <TranscriptSegment
+        segment={segment}
+        speakers={speakers}
+        isSelected={false}
+        isActive={false}
+        currentTime={0}
+        onSelect={vi.fn()}
+        onTextChange={vi.fn()}
+        onSpeakerChange={vi.fn()}
+        onSplit={vi.fn()}
+        onDelete={vi.fn()}
+        onSeek={onSeek}
+      />,
+    );
+
+    const word = screen.getByTestId("word-seg-1-0");
+    fireEvent.keyDown(word, { key: " " });
+
+    expect(onSeek).toHaveBeenCalledWith(0);
+  });
+
+  it("uses fallback speaker color when missing speaker data", () => {
+    render(
+      <TranscriptSegment
+        segment={segment}
+        speakers={[]}
+        isSelected={false}
+        isActive={false}
+        currentTime={0}
+        onSelect={vi.fn()}
+        onTextChange={vi.fn()}
+        onSpeakerChange={vi.fn()}
+        onSplit={vi.fn()}
+        onDelete={vi.fn()}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    const segmentCard = screen.getByTestId("segment-seg-1");
+    const colorSwatch = segmentCard.querySelector("div[style]");
+
+    expect(colorSwatch).toHaveStyle({ backgroundColor: "hsl(217, 91%, 48%)" });
+  });
 });

--- a/client/src/components/ui/__tests__/pagination.test.tsx
+++ b/client/src/components/ui/__tests__/pagination.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+
+describe("Pagination components", () => {
+  it("renders navigation and active links", () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#" isActive>
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">2</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationEllipsis />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+
+    expect(screen.getByLabelText("pagination")).toBeInTheDocument();
+    expect(screen.getByLabelText("Go to previous page")).toBeInTheDocument();
+    expect(screen.getByLabelText("Go to next page")).toBeInTheDocument();
+    expect(screen.getByText("1")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByText("2")).not.toHaveAttribute("aria-current");
+    expect(screen.getByText("More pages")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/ui/pagination.tsx
+++ b/client/src/components/ui/pagination.tsx
@@ -5,7 +5,6 @@ import { cn } from "@/lib/utils";
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav
-    role="navigation"
     aria-label="pagination"
     className={cn("mx-auto flex w-full justify-center", className)}
     {...props}


### PR DESCRIPTION
### Motivation

- Address several non-critical Biome lint warnings related to accessibility and hook usage reported by `biome check` for UI components.
- Make transcript word interactions keyboard-accessible and ensure semantic roles are correct to improve a11y.
- Add tests to raise coverage for the modified code paths and to prevent regressions.

### Description

- Make `TranscriptSegment` words and container keyboard-accessible by adding `role="button"`, `tabIndex`, `aria-pressed` on the container, and keyboard handlers for Enter/Space to invoke existing click behavior.
- Factor word activation into `handleWordAction` and wire both mouse and keyboard events to it, and ensure the editable text block supports keyboard save/cancel (Enter/Escape).
- Remove redundant `role="navigation"` from the `Pagination` component.
- Add unit tests for `TranscriptSegment` (Enter/Escape handling, keyboard seek, fallback speaker color) and a new `pagination` test to cover the pagination component.

### Testing

- Ran `npm test -- --coverage` after the changes which executed the test suite and coverage reporter.
- All automated tests passed (`23 passed` total) and the coverage report was generated successfully.
- New unit tests exercise keyboard interactions and fallback rendering for `TranscriptSegment` and verify pagination markup.
- No test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b1aa0cc48323bb7c2372fbef8750)