### PR TITLE
bug: highlight active spellcheck and glossary

### DIFF
--- a/client/src/components/transcript-editor/Toolbar.tsx
+++ b/client/src/components/transcript-editor/Toolbar.tsx
@@ -24,6 +24,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Separator } from "@/components/ui/separator";
 import { Slider } from "@/components/ui/slider";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 import { FileUpload } from "../FileUpload";
 import { ThemeToggle } from "../ThemeToggle";
 import type { TranscriptEditorState } from "./useTranscriptEditor";
@@ -67,6 +68,8 @@ export function Toolbar({
   spellcheckDebugEnabled,
   effectiveSpellcheckLanguages,
   spellcheckerLanguages,
+  spellcheckHighlightActive,
+  glossaryHighlightActive,
   onShowGlossary,
 }: ToolbarProps) {
   return (
@@ -264,7 +267,11 @@ export function Toolbar({
                       onClick={() => onSpellcheckPopoverChange(true)}
                       aria-label="Spellcheck settings"
                       data-testid="button-spellcheck"
-                      className="px-2 gap-2"
+                      aria-pressed={spellcheckHighlightActive}
+                      className={cn(
+                        "px-2 gap-2",
+                        spellcheckHighlightActive && "bg-accent text-accent-foreground",
+                      )}
                     >
                       <SpellCheck className="h-4 w-4" aria-hidden="true" />
                       <span className="hidden sm:inline">Spellcheck</span>
@@ -373,7 +380,11 @@ export function Toolbar({
                   onClick={onShowGlossary}
                   aria-label="Glossary settings"
                   data-testid="button-glossary"
-                  className="px-2 gap-2"
+                  aria-pressed={glossaryHighlightActive}
+                  className={cn(
+                    "px-2 gap-2",
+                    glossaryHighlightActive && "bg-accent text-accent-foreground",
+                  )}
                 >
                   <BookOpenText className="h-4 w-4" aria-hidden="true" />
                   <span className="hidden sm:inline">Glossary</span>

--- a/client/src/components/transcript-editor/__tests__/Toolbar.test.tsx
+++ b/client/src/components/transcript-editor/__tests__/Toolbar.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Toolbar } from "@/components/transcript-editor/Toolbar";
+import type { TranscriptEditorState } from "@/components/transcript-editor/useTranscriptEditor";
+
+vi.mock("@/components/FileUpload", () => ({
+  FileUpload: () => <div data-testid="file-upload" />,
+}));
+
+vi.mock("@/components/ThemeToggle", () => ({
+  ThemeToggle: () => <div data-testid="theme-toggle" />,
+}));
+
+const baseProps: TranscriptEditorState["toolbarProps"] = {
+  sidebarOpen: true,
+  onToggleSidebar: vi.fn(),
+  onAudioUpload: vi.fn(),
+  onTranscriptUpload: vi.fn(),
+  audioFileName: undefined,
+  transcriptFileName: undefined,
+  transcriptLoaded: true,
+  recentSessions: [],
+  onActivateSession: vi.fn(),
+  onUndo: vi.fn(),
+  onRedo: vi.fn(),
+  canUndo: false,
+  canRedo: false,
+  onShowShortcuts: vi.fn(),
+  onShowExport: vi.fn(),
+  highlightLowConfidence: false,
+  onToggleHighlightLowConfidence: vi.fn(),
+  confidencePopoverOpen: false,
+  onConfidencePopoverChange: vi.fn(),
+  lowConfidenceThreshold: 0.4,
+  onManualConfidenceChange: vi.fn(),
+  onResetConfidenceThreshold: vi.fn(),
+  spellcheckPopoverOpen: false,
+  onSpellcheckPopoverChange: vi.fn(),
+  spellcheckEnabled: false,
+  onToggleSpellcheck: vi.fn(),
+  spellcheckLanguages: [],
+  onSpellcheckLanguageChange: vi.fn(),
+  spellcheckCustomEnabled: false,
+  onToggleSpellcheckCustom: vi.fn(),
+  onShowCustomDictionaries: vi.fn(),
+  spellcheckCustomDictionariesCount: 0,
+  onShowSpellcheckDialog: vi.fn(),
+  spellcheckDebugEnabled: false,
+  effectiveSpellcheckLanguages: [],
+  spellcheckerLanguages: [],
+  spellcheckHighlightActive: false,
+  glossaryHighlightActive: false,
+  onShowGlossary: vi.fn(),
+};
+
+describe("Toolbar", () => {
+  it("highlights the spellcheck button when spellcheck highlighting is active", () => {
+    render(<Toolbar {...baseProps} spellcheckHighlightActive={true} />);
+
+    const spellcheckButton = screen.getByTestId("button-spellcheck");
+    expect(spellcheckButton).toHaveClass("bg-accent");
+    expect(spellcheckButton).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("highlights the glossary button when glossary highlighting is active", () => {
+    render(<Toolbar {...baseProps} glossaryHighlightActive={true} />);
+
+    const glossaryButton = screen.getByTestId("button-glossary");
+    expect(glossaryButton).toHaveClass("bg-accent");
+    expect(glossaryButton).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/client/src/components/transcript-editor/useTranscriptEditor.ts
+++ b/client/src/components/transcript-editor/useTranscriptEditor.ts
@@ -1277,6 +1277,8 @@ export const useTranscriptEditor = () => {
     spellcheckDebugEnabled,
     effectiveSpellcheckLanguages,
     spellcheckerLanguages: spellcheckers.map((checker) => checker.language),
+    spellcheckHighlightActive: showSpellcheckMatches,
+    glossaryHighlightActive: showLexiconMatches,
     onShowGlossary: () => setShowLexicon(true),
   };
 


### PR DESCRIPTION
## Summary
- highlight the spellcheck toolbar control when misspelling highlights are active
- show the glossary button as active when glossary highlighting is enabled
- add focused toolbar tests to cover the new active states

## Testing
- npm test -- --reporter basic
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d922ab1108323b80bacbeedf00865)