### PR TITLE
fix: make chapter batch warning threshold feature-specific

### DIFF
--- a/client/src/components/AICommandPanel/AIConfigurationSection.tsx
+++ b/client/src/components/AICommandPanel/AIConfigurationSection.tsx
@@ -32,6 +32,7 @@ interface AIConfigurationSectionProps {
   batchSizeMin?: number;
   batchSizeMax?: number;
   batchSizeHelp?: string;
+  batchSizeWarningThreshold?: number;
   showBatchSize?: boolean;
   onProviderChange: (value: string) => void;
   onModelChange: (value: string) => void;
@@ -53,6 +54,7 @@ export function AIConfigurationSection({
   batchSizeMin = 1,
   batchSizeMax = 50,
   batchSizeHelp,
+  batchSizeWarningThreshold = 10,
   showBatchSize = true,
   onProviderChange,
   onModelChange,
@@ -225,10 +227,10 @@ export function AIConfigurationSection({
             ) : null}
           </div>
 
-          {Number(batchSize) > 10 ? (
+          {Number(batchSize) > batchSizeWarningThreshold ? (
             <p className="flex items-start gap-1 text-xs text-amber-600 dark:text-amber-400">
               <AlertCircle className="mt-0.5 h-3 w-3 shrink-0" />
-              {t("aiBatch.merge.batchSizeWarning")}
+              {t("aiBatch.config.batchSizeWarning", { threshold: batchSizeWarningThreshold })}
             </p>
           ) : null}
         </div>

--- a/client/src/components/AICommandPanel/ChapterPanel.tsx
+++ b/client/src/components/AICommandPanel/ChapterPanel.tsx
@@ -132,6 +132,7 @@ export function ChapterPanel({ filteredSegmentIds, onOpenSettings }: Readonly<Ch
         batchSize={batchSize}
         batchSizeMin={10}
         batchSizeMax={200}
+        batchSizeWarningThreshold={100}
         batchSizeHelp={t("aiBatch.chapter.batchSizeHelp")}
         onProviderChange={(value) => {
           selectProvider(value);

--- a/client/src/components/AICommandPanel/__tests__/AIConfigurationSection.test.tsx
+++ b/client/src/components/AICommandPanel/__tests__/AIConfigurationSection.test.tsx
@@ -70,4 +70,47 @@ describe("AIConfigurationSection", () => {
 
     expect(handleBatchSizeChange).toHaveBeenCalledWith("25");
   });
+
+  it("shows warning above default threshold", () => {
+    renderWithI18n(
+      <AIConfigurationSection
+        id="test"
+        settings={settings}
+        selectedProviderId="provider-1"
+        selectedModel=""
+        isProcessing={false}
+        promptValue="prompt-1"
+        promptOptions={[{ id: "prompt-1", name: "Default Prompt" }]}
+        batchSize="11"
+        onProviderChange={vi.fn()}
+        onModelChange={vi.fn()}
+        onPromptChange={vi.fn()}
+        onBatchSizeChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/high batch sizes \(> 10\)/i)).toBeInTheDocument();
+  });
+
+  it("uses custom warning threshold for chapter workflow", () => {
+    renderWithI18n(
+      <AIConfigurationSection
+        id="test"
+        settings={settings}
+        selectedProviderId="provider-1"
+        selectedModel=""
+        isProcessing={false}
+        promptValue="prompt-1"
+        promptOptions={[{ id: "prompt-1", name: "Default Prompt" }]}
+        batchSize="99"
+        batchSizeWarningThreshold={100}
+        onProviderChange={vi.fn()}
+        onModelChange={vi.fn()}
+        onPromptChange={vi.fn()}
+        onBatchSizeChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/high batch sizes/i)).not.toBeInTheDocument();
+  });
 });

--- a/client/src/components/AICommandPanel/__tests__/ChapterPanel.test.tsx
+++ b/client/src/components/AICommandPanel/__tests__/ChapterPanel.test.tsx
@@ -142,4 +142,29 @@ describe("ChapterPanel", () => {
 
     expect(startChapterDetection).not.toHaveBeenCalled();
   });
+
+  it("uses a higher batch warning threshold for chapter detection", async () => {
+    const user = userEvent.setup();
+
+    setStoreState({
+      segments: baseSegments,
+    });
+
+    renderWithI18n(<ChapterPanel filteredSegmentIds={["seg-1"]} onOpenSettings={vi.fn()} />);
+
+    const batchSizeInput = screen.getByLabelText(/batch size/i);
+    await act(async () => {
+      await user.clear(batchSizeInput);
+      await user.type(batchSizeInput, "99");
+    });
+
+    expect(screen.queryByText(/high batch sizes \(> 100\)/i)).not.toBeInTheDocument();
+
+    await act(async () => {
+      await user.clear(batchSizeInput);
+      await user.type(batchSizeInput, "101");
+    });
+
+    expect(screen.getByText(/high batch sizes \(> 100\)/i)).toBeInTheDocument();
+  });
 });

--- a/client/src/translations/de.json
+++ b/client/src/translations/de.json
@@ -165,6 +165,7 @@
       "noModelConfigured": "Kein Modell konfiguriert",
       "batchSizeLabel": "Batch-Größe",
       "batchSizeHelp": "Anzahl der Segmente pro Batch (1-50)",
+      "batchSizeWarning": "Hohe Batch-Größen (> {{threshold}}) können das Kontextfenster einiger Modelle überschreiten. Reduzieren, falls Fehler auftreten.",
       "settingsTooltip": "KI-Anbieter und Prompts konfigurieren",
       "noProviderConfigured": "Kein KI-Anbieter konfiguriert. Bitte in Einstellungen → KI → Server & Modelle hinzufügen."
     },

--- a/client/src/translations/en.json
+++ b/client/src/translations/en.json
@@ -218,6 +218,7 @@
       "noModelConfigured": "No model configured",
       "batchSizeLabel": "Batch Size",
       "batchSizeHelp": "Number of segments to process in each batch (1-50)",
+      "batchSizeWarning": "High batch sizes (> {{threshold}}) may exceed some models' context window. Reduce if you encounter errors.",
       "settingsTooltip": "Configure AI providers and prompts",
       "noProviderConfigured": "No AI provider configured. Add one in Settings → AI → Server & Models."
     },


### PR DESCRIPTION
## Summary
- make `AIConfigurationSection` use a configurable batch warning threshold instead of a hardcoded `> 10`
- set Chapter Detection to warn only above `100` while preserving `10` as default for other features
- add tests for default and custom warning thresholds plus ChapterPanel behavior, and add a new i18n warning key with threshold interpolation

## Verification
- `npm run check`
- `npm run lint:fix`
- `npm test` (166 passed / 1570 passed)