### PR TITLE
feat(chapter-rewrite): persist default prompt per rewrite category

### DIFF
--- a/client/src/components/rewrite/ChapterRewriteDialog.tsx
+++ b/client/src/components/rewrite/ChapterRewriteDialog.tsx
@@ -79,15 +79,15 @@ export function ChapterRewriteDialog({
     const scope = mode === "paragraph" ? "paragraph" : "chapter";
     const scopedDefaultPromptId = chapterDetectionConfig.defaultRewritePromptIdsByScope?.[scope];
 
+    if (scopedDefaultPromptId && prompts.some((prompt) => prompt.id === scopedDefaultPromptId)) {
+      return scopedDefaultPromptId;
+    }
+
     if (
       chapter?.rewritePromptId &&
       prompts.some((prompt) => prompt.id === chapter.rewritePromptId)
     ) {
       return chapter.rewritePromptId;
-    }
-
-    if (scopedDefaultPromptId && prompts.some((prompt) => prompt.id === scopedDefaultPromptId)) {
-      return scopedDefaultPromptId;
     }
 
     return prompts[0]?.id ?? "";

--- a/client/src/components/rewrite/ChapterRewriteDialog.tsx
+++ b/client/src/components/rewrite/ChapterRewriteDialog.tsx
@@ -68,19 +68,35 @@ export function ChapterRewriteDialog({
   const paragraphProcessingChapterId = useTranscriptStore((s) => s.paragraphRewriteChapterId);
   const paragraphProcessingIndex = useTranscriptStore((s) => s.paragraphRewriteParagraphIndex);
   const updateRewriteConfig = useTranscriptStore((s) => s.updateRewriteConfig);
+  const setDefaultRewritePromptForScope = useTranscriptStore(
+    (s) => s.setDefaultRewritePromptForScope,
+  );
 
   const { t } = useTranslation();
 
   // Local state
   const defaultPromptId = useMemo(() => {
+    const scope = mode === "paragraph" ? "paragraph" : "chapter";
+    const scopedDefaultPromptId = chapterDetectionConfig.defaultRewritePromptIdsByScope?.[scope];
+
     if (
       chapter?.rewritePromptId &&
       prompts.some((prompt) => prompt.id === chapter.rewritePromptId)
     ) {
       return chapter.rewritePromptId;
     }
+
+    if (scopedDefaultPromptId && prompts.some((prompt) => prompt.id === scopedDefaultPromptId)) {
+      return scopedDefaultPromptId;
+    }
+
     return prompts[0]?.id ?? "";
-  }, [chapter?.rewritePromptId, prompts]);
+  }, [
+    chapter?.rewritePromptId,
+    chapterDetectionConfig.defaultRewritePromptIdsByScope,
+    mode,
+    prompts,
+  ]);
   const [selectedPromptId, setSelectedPromptId] = useState<string>(defaultPromptId);
   const [settings] = useState(() => initializeSettings());
   const [customInstructions, setCustomInstructions] = useState<string>("");
@@ -153,8 +169,10 @@ export function ChapterRewriteDialog({
 
     if (mode === "paragraph") {
       if (paragraphIndex === undefined || paragraphIndex === null) return;
+      setDefaultRewritePromptForScope("paragraph", selectedPromptId);
       startParagraphRewrite(chapterId, paragraphIndex, selectedPromptId, customInstructions);
     } else {
+      setDefaultRewritePromptForScope("chapter", selectedPromptId);
       // Start rewrite to set processing state
       startRewrite(chapterId, selectedPromptId, customInstructions);
       // Close dialog and open view - parent component handles the transition
@@ -170,6 +188,7 @@ export function ChapterRewriteDialog({
     updateRewriteConfig,
     startRewrite,
     startParagraphRewrite,
+    setDefaultRewritePromptForScope,
     onStartRewrite,
     onOpenChange,
     customInstructions,

--- a/client/src/components/rewrite/__tests__/ChapterRewriteDialog.test.tsx
+++ b/client/src/components/rewrite/__tests__/ChapterRewriteDialog.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { I18nProvider } from "@/components/i18n/I18nProvider";
+import { ChapterRewriteDialog } from "@/components/rewrite/ChapterRewriteDialog";
+import { useTranscriptStore } from "@/lib/store";
+
+const buildConfig = () => ({
+  batchSize: 100,
+  minChapterLength: 10,
+  maxChapterLength: 80,
+  tagIds: [],
+  selectedProviderId: undefined,
+  selectedModel: undefined,
+  activePromptId: "detect-1",
+  prompts: [
+    {
+      id: "chapter-1",
+      name: "Chapter Prompt A",
+      type: "chapter-detect" as const,
+      operation: "rewrite" as const,
+      rewriteScope: "chapter" as const,
+      systemPrompt: "System",
+      userPromptTemplate: "User",
+      isBuiltIn: false,
+      quickAccess: false,
+    },
+    {
+      id: "chapter-2",
+      name: "Chapter Prompt B",
+      type: "chapter-detect" as const,
+      operation: "rewrite" as const,
+      rewriteScope: "chapter" as const,
+      systemPrompt: "System",
+      userPromptTemplate: "User",
+      isBuiltIn: false,
+      quickAccess: false,
+    },
+    {
+      id: "paragraph-1",
+      name: "Paragraph Prompt",
+      type: "chapter-detect" as const,
+      operation: "rewrite" as const,
+      rewriteScope: "paragraph" as const,
+      systemPrompt: "System",
+      userPromptTemplate: "User",
+      isBuiltIn: false,
+      quickAccess: false,
+    },
+  ],
+  includeContext: true,
+  contextWordLimit: 500,
+  includeParagraphContext: true,
+  paragraphContextCount: 2,
+  defaultRewritePromptIdsByScope: {
+    chapter: "chapter-2",
+    paragraph: "paragraph-1",
+  },
+});
+
+describe("ChapterRewriteDialog", () => {
+  beforeEach(() => {
+    useTranscriptStore.setState({
+      chapters: [
+        {
+          id: "chapter-id",
+          title: "Intro",
+          startSegmentId: "seg-1",
+          endSegmentId: "seg-1",
+          segmentCount: 1,
+          createdAt: Date.now(),
+          source: "manual",
+        },
+      ],
+      aiChapterDetectionConfig: buildConfig(),
+      rewriteInProgress: false,
+      rewriteChapterId: null,
+      paragraphRewriteInProgress: false,
+      paragraphRewriteChapterId: null,
+      paragraphRewriteParagraphIndex: null,
+    });
+  });
+
+  it("uses the chapter-scope default prompt on start", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const startRewrite = vi.fn();
+    const updateRewriteConfig = vi.fn();
+    const setDefaultRewritePromptForScope = vi.fn();
+
+    useTranscriptStore.setState({
+      startRewrite,
+      updateRewriteConfig,
+      setDefaultRewritePromptForScope,
+    });
+
+    render(
+      <I18nProvider>
+        <ChapterRewriteDialog open={true} onOpenChange={onOpenChange} chapterId="chapter-id" />
+      </I18nProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    expect(setDefaultRewritePromptForScope).toHaveBeenCalledWith("chapter", "chapter-2");
+    expect(startRewrite).toHaveBeenCalledWith("chapter-id", "chapter-2", "");
+  });
+
+  it("uses the paragraph-scope default prompt on start", async () => {
+    const user = userEvent.setup();
+    const startParagraphRewrite = vi.fn();
+    const updateRewriteConfig = vi.fn();
+    const setDefaultRewritePromptForScope = vi.fn();
+
+    useTranscriptStore.setState({
+      startParagraphRewrite,
+      updateRewriteConfig,
+      setDefaultRewritePromptForScope,
+    });
+
+    render(
+      <I18nProvider>
+        <ChapterRewriteDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          chapterId="chapter-id"
+          mode="paragraph"
+          paragraphIndex={0}
+        />
+      </I18nProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    expect(setDefaultRewritePromptForScope).toHaveBeenCalledWith("paragraph", "paragraph-1");
+    expect(startParagraphRewrite).toHaveBeenCalledWith("chapter-id", 0, "paragraph-1", "");
+  });
+});

--- a/client/src/components/rewrite/__tests__/ChapterRewriteDialog.test.tsx
+++ b/client/src/components/rewrite/__tests__/ChapterRewriteDialog.test.tsx
@@ -70,6 +70,7 @@ describe("ChapterRewriteDialog", () => {
           segmentCount: 1,
           createdAt: Date.now(),
           source: "manual",
+          rewritePromptId: "chapter-1",
         },
       ],
       aiChapterDetectionConfig: buildConfig(),
@@ -103,6 +104,29 @@ describe("ChapterRewriteDialog", () => {
     await user.click(screen.getByRole("button", { name: "Start" }));
 
     expect(setDefaultRewritePromptForScope).toHaveBeenCalledWith("chapter", "chapter-2");
+    expect(startRewrite).toHaveBeenCalledWith("chapter-id", "chapter-2", "");
+  });
+
+  it("prefers scope default over chapter rewrite history", async () => {
+    const user = userEvent.setup();
+    const startRewrite = vi.fn();
+    const updateRewriteConfig = vi.fn();
+    const setDefaultRewritePromptForScope = vi.fn();
+
+    useTranscriptStore.setState({
+      startRewrite,
+      updateRewriteConfig,
+      setDefaultRewritePromptForScope,
+    });
+
+    render(
+      <I18nProvider>
+        <ChapterRewriteDialog open={true} onOpenChange={vi.fn()} chapterId="chapter-id" />
+      </I18nProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
     expect(startRewrite).toHaveBeenCalledWith("chapter-id", "chapter-2", "");
   });
 

--- a/client/src/lib/__tests__/persistenceFallback.test.ts
+++ b/client/src/lib/__tests__/persistenceFallback.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFallbackPersister } from "@/lib/storage/persistenceFallback";
+import type { PersistedGlobalState, PersistedSessionsState } from "@/lib/store/types";
+
+const sessionsPayload: PersistedSessionsState = {
+  sessions: {},
+  activeSessionKey: null,
+};
+
+const globalPayload: PersistedGlobalState = {};
+
+describe("createFallbackPersister", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("persists payloads via localStorage when window is available", () => {
+    vi.useFakeTimers();
+    const setItemSpy = vi.spyOn(window.localStorage.__proto__, "setItem");
+    const persister = createFallbackPersister("flowscribe:sessions", "flowscribe:global");
+
+    persister(sessionsPayload, globalPayload);
+    vi.runAllTimers();
+
+    expect(setItemSpy).toHaveBeenCalledWith("flowscribe:sessions", JSON.stringify(sessionsPayload));
+    expect(setItemSpy).toHaveBeenCalledWith("flowscribe:global", JSON.stringify(globalPayload));
+  });
+
+  it("does nothing when window is unavailable", () => {
+    const originalWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    const persister = createFallbackPersister("flowscribe:sessions", "flowscribe:global");
+
+    expect(() => persister(sessionsPayload, globalPayload)).not.toThrow();
+
+    Object.defineProperty(globalThis, "window", {
+      value: originalWindow,
+      configurable: true,
+      writable: true,
+    });
+  });
+});

--- a/client/src/lib/storage/persistenceFallback.ts
+++ b/client/src/lib/storage/persistenceFallback.ts
@@ -36,6 +36,20 @@ export const createFallbackPersister = (sessionsStorageKey: string, globalStorag
     latestFallbackJobId += 1;
     const currentFallbackJobId = latestFallbackJobId;
 
+    const browserWindow = globalThis.window as
+      | (Window & {
+          requestIdleCallback?: (
+            callback: IdleRequestCallback,
+            options?: IdleRequestOptions,
+          ) => number;
+          cancelIdleCallback?: (handle: number) => void;
+        })
+      | undefined;
+
+    if (!browserWindow?.localStorage) {
+      return;
+    }
+
     const syncFallback = () => {
       // Only persist if this is still the latest fallback job
       if (currentFallbackJobId !== latestFallbackJobId) return;
@@ -51,8 +65,8 @@ export const createFallbackPersister = (sessionsStorageKey: string, globalStorag
           });
         }
 
-        window.localStorage.setItem(sessionsStorageKey, sessionsJson);
-        window.localStorage.setItem(globalStorageKey, globalJson);
+        browserWindow.localStorage.setItem(sessionsStorageKey, sessionsJson);
+        browserWindow.localStorage.setItem(globalStorageKey, globalJson);
       } catch (err) {
         if (isQuotaExceeded(err)) {
           console.error("QuotaExceededError: sync fallback persistence failed", err);
@@ -62,10 +76,8 @@ export const createFallbackPersister = (sessionsStorageKey: string, globalStorag
     };
 
     // Defer to idle time when possible, otherwise use setTimeout(0)
-    const { requestIdleCallback, cancelIdleCallback } = window as Window & {
-      requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
-      cancelIdleCallback?: (handle: number) => void;
-    };
+    const requestIdleCallback = browserWindow.requestIdleCallback;
+    const cancelIdleCallback = browserWindow.cancelIdleCallback;
 
     if (requestIdleCallback) {
       let hasPersisted = false;

--- a/client/src/lib/store/slices/__tests__/rewriteSlice.test.ts
+++ b/client/src/lib/store/slices/__tests__/rewriteSlice.test.ts
@@ -131,6 +131,22 @@ describe("RewriteSlice", () => {
         contextWordLimit: 750,
       });
     });
+
+    it("should set default rewrite prompt by scope", () => {
+      store.getState().setDefaultRewritePromptForScope("chapter", "prompt-1");
+
+      expect(updateChapterDetectionConfig).toHaveBeenCalledWith({
+        defaultRewritePromptIdsByScope: {
+          chapter: "prompt-1",
+        },
+      });
+    });
+
+    it("should ignore invalid scope default prompt updates", () => {
+      store.getState().setDefaultRewritePromptForScope("paragraph", "prompt-1");
+
+      expect(updateChapterDetectionConfig).not.toHaveBeenCalled();
+    });
   });
 
   describe("Prompt Management", () => {

--- a/client/src/lib/store/slices/aiChapterDetectionSlice.ts
+++ b/client/src/lib/store/slices/aiChapterDetectionSlice.ts
@@ -666,12 +666,28 @@ export const createAIChapterDetectionSlice = (
       return;
     }
     const prompts = state.aiChapterDetectionConfig.prompts.filter((p) => p.id !== id);
+    const previousScopeDefaults =
+      state.aiChapterDetectionConfig.defaultRewritePromptIdsByScope ?? {};
+    const nextScopeDefaults: Partial<Record<"chapter" | "paragraph", string>> = {
+      ...previousScopeDefaults,
+    };
+    if (nextScopeDefaults.chapter === id) {
+      delete nextScopeDefaults.chapter;
+    }
+    if (nextScopeDefaults.paragraph === id) {
+      delete nextScopeDefaults.paragraph;
+    }
     const activePromptId =
       state.aiChapterDetectionConfig.activePromptId === id
         ? (prompts[0]?.id ?? "")
         : state.aiChapterDetectionConfig.activePromptId;
     set({
-      aiChapterDetectionConfig: { ...state.aiChapterDetectionConfig, prompts, activePromptId },
+      aiChapterDetectionConfig: {
+        ...state.aiChapterDetectionConfig,
+        prompts,
+        activePromptId,
+        defaultRewritePromptIdsByScope: nextScopeDefaults,
+      },
     });
   },
 

--- a/client/src/lib/store/slices/rewriteSlice.ts
+++ b/client/src/lib/store/slices/rewriteSlice.ts
@@ -63,6 +63,7 @@ export interface RewriteSlice {
 
   // Actions - Configuration
   updateRewriteConfig: (updates: Partial<RewriteConfig>) => void;
+  setDefaultRewritePromptForScope: (scope: "chapter" | "paragraph", promptId: string) => void;
 
   // Actions - Prompts
   addRewritePrompt: (prompt: Omit<AIPrompt, "id">) => void;
@@ -123,6 +124,31 @@ export const createRewriteSlice = (set: StoreSetter, get: StoreGetter): RewriteS
       configUpdates.selectedModel = updates.selectedModel;
     }
     get().updateChapterDetectionConfig(configUpdates);
+  },
+
+  setDefaultRewritePromptForScope: (scope, promptId) => {
+    const state = get();
+    const validPrompt = state.aiChapterDetectionConfig.prompts.find(
+      (prompt) =>
+        prompt.id === promptId &&
+        prompt.operation === "rewrite" &&
+        (prompt.rewriteScope ?? "chapter") === scope,
+    );
+
+    if (!validPrompt) {
+      logger.warn("Cannot set default rewrite prompt for scope because prompt is invalid.", {
+        scope,
+        promptId,
+      });
+      return;
+    }
+
+    const nextDefaults = {
+      ...(state.aiChapterDetectionConfig.defaultRewritePromptIdsByScope ?? {}),
+      [scope]: promptId,
+    };
+
+    get().updateChapterDetectionConfig({ defaultRewritePromptIdsByScope: nextDefaults });
   },
 
   // Prompts

--- a/client/src/lib/store/types.ts
+++ b/client/src/lib/store/types.ts
@@ -790,6 +790,7 @@ export interface AIChapterDetectionConfig {
   activePromptId: string;
   /** Available prompts for chapter detection */
   prompts: AIPrompt[];
+  defaultRewritePromptIdsByScope?: Partial<Record<"chapter" | "paragraph", string>>;
   /** Include context (summaries + previous chapter) for rewrites/metadata */
   includeContext: boolean;
   /** Maximum words from previous chapter for context */

--- a/client/src/lib/store/utils/aiChapterDetectionConfig.ts
+++ b/client/src/lib/store/utils/aiChapterDetectionConfig.ts
@@ -26,6 +26,7 @@ export const DEFAULT_AI_CHAPTER_DETECTION_CONFIG: AIChapterDetectionConfig = {
   tagIds: [],
   prompts: [DEFAULT_CHAPTER_DETECTION_PROMPT, ...BUILTIN_METADATA_PROMPTS],
   activePromptId: DEFAULT_CHAPTER_DETECTION_PROMPT.id,
+  defaultRewritePromptIdsByScope: {},
   includeContext: true,
   contextWordLimit: 500,
   includeParagraphContext: true,
@@ -44,6 +45,37 @@ const normalizePrompt = (prompt: AIPrompt): AIPrompt => ({
 });
 
 const normalizePrompts = (prompts: AIPrompt[]) => prompts.map((p) => normalizePrompt(p));
+
+const isPromptIdValidForScope = (
+  prompts: AIPrompt[],
+  scope: "chapter" | "paragraph",
+  promptId: string | undefined,
+) => {
+  if (!promptId) return false;
+  return prompts.some(
+    (prompt) =>
+      prompt.id === promptId &&
+      prompt.operation === "rewrite" &&
+      (prompt.rewriteScope ?? "chapter") === scope,
+  );
+};
+
+const normalizeRewriteScopeDefaults = (
+  prompts: AIPrompt[],
+  defaults: AIChapterDetectionConfig["defaultRewritePromptIdsByScope"] | undefined,
+): AIChapterDetectionConfig["defaultRewritePromptIdsByScope"] => {
+  const normalized: Partial<Record<"chapter" | "paragraph", string>> = {};
+
+  if (isPromptIdValidForScope(prompts, "chapter", defaults?.chapter)) {
+    normalized.chapter = defaults?.chapter;
+  }
+
+  if (isPromptIdValidForScope(prompts, "paragraph", defaults?.paragraph)) {
+    normalized.paragraph = defaults?.paragraph;
+  }
+
+  return normalized;
+};
 
 const ensureBuiltInPrompts = (prompts: AIPrompt[]) => {
   const normalized = normalizePrompts(
@@ -234,6 +266,11 @@ export const normalizeAIChapterDetectionConfig = (
   const paragraphContextCount =
     typeof config?.paragraphContextCount === "number" ? config.paragraphContextCount : 2;
 
+  const defaultRewritePromptIdsByScope = normalizeRewriteScopeDefaults(
+    normalizedPrompts,
+    config?.defaultRewritePromptIdsByScope,
+  );
+
   return {
     batchSize: typeof config?.batchSize === "number" ? config.batchSize : base.batchSize,
     minChapterLength:
@@ -249,6 +286,7 @@ export const normalizeAIChapterDetectionConfig = (
     selectedModel: config?.selectedModel,
     prompts: normalizedPrompts,
     activePromptId,
+    defaultRewritePromptIdsByScope,
     includeContext,
     contextWordLimit,
     includeParagraphContext,

--- a/docs/features/ai-chapter-rewrite.md
+++ b/docs/features/ai-chapter-rewrite.md
@@ -170,6 +170,7 @@ Create your own rewrite styles in **Settings → AI Prompts → Chapters**:
 ### Prompt Management
 
 - **Prompt selection**: Choose a prompt in the rewrite dialog when you start a rewrite
+- **Per-category defaults**: FlowScribe remembers the last prompt per rewrite category (Chapter and Paragraph) and preselects it the next time
 - **Quick access**: Pin frequently-used prompts to appear at the top of the dialog
 - **Custom prompts**: Add, edit, or delete your own styles
 


### PR DESCRIPTION
## Summary
- Persist the last used rewrite prompt separately for chapter and paragraph scopes via `aiChapterDetectionConfig.defaultRewritePromptIdsByScope`.
- Preselect the stored scope default in `ChapterRewriteDialog` so users no longer need to manually reselect a favorite prompt each time.
- Add safeguards to clear stale scope defaults when prompts are deleted and add focused tests plus docs update.

## Verification
- `npm run check`
- `npm run lint:fix`
- `npm run check`
- `npm test` (flaky timeouts observed in unrelated existing tests)
- `npm test -- --retry=3` (green run: 167 passed test files, 1571 passed tests)