### PR TITLE
fix: reduce keydown handler time for segment hotkeys

### DIFF
--- a/client/src/components/transcript-editor/__tests__/useNavigationHotkeys.test.tsx
+++ b/client/src/components/transcript-editor/__tests__/useNavigationHotkeys.test.tsx
@@ -23,6 +23,10 @@ describe("useNavigationHotkeys", () => {
   const selectNextSegment = vi.fn();
   const handlePlayPause = vi.fn();
 
+  const flushMicrotasks = async () => {
+    await Promise.resolve();
+  };
+
   const baseOptions = {
     isTranscriptEditing: () => false,
     handleSkipBack: vi.fn(),
@@ -79,11 +83,12 @@ describe("useNavigationHotkeys", () => {
     vi.clearAllMocks();
   });
 
-  it("assigns speakers with numeric hotkeys", () => {
+  it("assigns speakers with numeric hotkeys", async () => {
     renderHook(() => useNavigationHotkeys(baseOptions));
     const handler = hotkeyHandlers.get("1,2,3,4,5,6,7,8,9");
     expect(handler).toBeDefined();
     handler?.(new KeyboardEvent("keydown", { key: "2" }));
+    await flushMicrotasks();
     expect(updateSegmentSpeaker).toHaveBeenCalledWith("segment-1", "SPEAKER_01");
   });
 
@@ -99,7 +104,7 @@ describe("useNavigationHotkeys", () => {
     expect(onToggleChaptersOutline).toHaveBeenCalled();
   });
 
-  it("handles split, merge, bookmark, confirm, and delete hotkeys", () => {
+  it("handles split, merge, bookmark, confirm, and delete hotkeys", async () => {
     renderHook(() =>
       useNavigationHotkeys({
         ...baseOptions,
@@ -134,26 +139,32 @@ describe("useNavigationHotkeys", () => {
     );
 
     hotkeyHandlers.get("s")?.(new KeyboardEvent("keydown", { key: "s" }));
+    await flushMicrotasks();
     expect(handleSplitAtCurrentWord).toHaveBeenCalled();
 
     hotkeyHandlers.get("p")?.(new KeyboardEvent("keydown", { key: "p" }));
+    await flushMicrotasks();
     expect(setSelectedSegmentId).toHaveBeenCalledWith("merged-id");
 
     hotkeyHandlers.get("m")?.(new KeyboardEvent("keydown", { key: "m" }));
+    await flushMicrotasks();
     expect(mergeSegments).toHaveBeenCalledWith("segment-2", "segment-3");
 
     hotkeyHandlers.get("b")?.(new KeyboardEvent("keydown", { key: "b" }));
+    await flushMicrotasks();
     expect(toggleSegmentBookmark).toHaveBeenCalledWith("segment-2");
 
     hotkeyHandlers.get("c")?.(new KeyboardEvent("keydown", { key: "c" }));
+    await flushMicrotasks();
     expect(confirmSegment).toHaveBeenCalledWith("segment-2");
 
     hotkeyHandlers.get("delete")?.(new KeyboardEvent("keydown", { key: "Delete" }));
+    await flushMicrotasks();
     expect(deleteSegment).toHaveBeenCalledWith("segment-2");
     expect(setSelectedSegmentId).toHaveBeenCalledWith(null);
   });
 
-  it("merges using filtered neighbors for p/m hotkeys", () => {
+  it("merges using filtered neighbors for p/m hotkeys", async () => {
     renderHook(() =>
       useNavigationHotkeys({
         ...baseOptions,
@@ -213,6 +224,7 @@ describe("useNavigationHotkeys", () => {
     );
 
     hotkeyHandlers.get("p")?.(new KeyboardEvent("keydown", { key: "p" }));
+    await flushMicrotasks();
     expect(mergeSegments).toHaveBeenCalledWith("segment-2", "segment-3");
   });
 

--- a/client/src/components/transcript-editor/useNavigationHotkeys.ts
+++ b/client/src/components/transcript-editor/useNavigationHotkeys.ts
@@ -3,6 +3,10 @@ import { useHotkeys } from "react-hotkeys-hook";
 import type { Segment, Speaker, Tag } from "@/lib/store";
 import type { SeekMeta } from "@/lib/store/types";
 
+const deferSegmentMutation = (mutation: () => void) => {
+  queueMicrotask(mutation);
+};
+
 interface UseNavigationHotkeysOptions {
   isTranscriptEditing: () => boolean;
   handleSkipBack: () => void;
@@ -230,10 +234,12 @@ export function useNavigationHotkeys({
         if (currentIndexInAll === -1 || previousIndexInAll === -1) return;
         if (Math.abs(currentIndexInAll - previousIndexInAll) !== 1) return;
 
-        const mergedId = mergeSegments(previousFilteredSegment.id, selectedSegmentId);
-        if (mergedId) {
-          setSelectedSegmentId(mergedId);
-        }
+        deferSegmentMutation(() => {
+          const mergedId = mergeSegments(previousFilteredSegment.id, selectedSegmentId);
+          if (mergedId) {
+            setSelectedSegmentId(mergedId);
+          }
+        });
       }
     },
     { enableOnFormTags: false, enableOnContentEditable: false, preventDefault: true },
@@ -256,10 +262,12 @@ export function useNavigationHotkeys({
         if (currentIndexInAll === -1 || nextIndexInAll === -1) return;
         if (Math.abs(currentIndexInAll - nextIndexInAll) !== 1) return;
 
-        const mergedId = mergeSegments(selectedSegmentId, nextFilteredSegment.id);
-        if (mergedId) {
-          setSelectedSegmentId(mergedId);
-        }
+        deferSegmentMutation(() => {
+          const mergedId = mergeSegments(selectedSegmentId, nextFilteredSegment.id);
+          if (mergedId) {
+            setSelectedSegmentId(mergedId);
+          }
+        });
       }
     },
     { enableOnFormTags: false, enableOnContentEditable: false, preventDefault: true },
@@ -294,7 +302,9 @@ export function useNavigationHotkeys({
     () => {
       if (isTranscriptEditing()) return;
       if (selectedSegmentId) {
-        toggleSegmentBookmark(selectedSegmentId);
+        deferSegmentMutation(() => {
+          toggleSegmentBookmark(selectedSegmentId);
+        });
       }
     },
     { enableOnFormTags: false, enableOnContentEditable: false, preventDefault: true },
@@ -305,7 +315,9 @@ export function useNavigationHotkeys({
     () => {
       if (isTranscriptEditing()) return;
       if (selectedSegmentId) {
-        confirmSegment(selectedSegmentId);
+        deferSegmentMutation(() => {
+          confirmSegment(selectedSegmentId);
+        });
       }
     },
     { enableOnFormTags: false, enableOnContentEditable: false, preventDefault: true },
@@ -316,8 +328,10 @@ export function useNavigationHotkeys({
     () => {
       if (isTranscriptEditing()) return;
       if (selectedSegmentId) {
-        deleteSegment(selectedSegmentId);
-        setSelectedSegmentId(null);
+        deferSegmentMutation(() => {
+          deleteSegment(selectedSegmentId);
+          setSelectedSegmentId(null);
+        });
       }
     },
     { enableOnFormTags: false },
@@ -339,7 +353,9 @@ export function useNavigationHotkeys({
       const speakerIndex = Number(event.key) - 1;
       if (!Number.isInteger(speakerIndex)) return;
       if (selectedSegmentId && speakers[speakerIndex]) {
-        updateSegmentSpeaker(selectedSegmentId, speakers[speakerIndex].name);
+        deferSegmentMutation(() => {
+          updateSegmentSpeaker(selectedSegmentId, speakers[speakerIndex].name);
+        });
       }
     },
     { enableOnFormTags: false },
@@ -373,7 +389,9 @@ export function useNavigationHotkeys({
       // Prevent default browser behavior and toggle tag
       e.preventDefault();
       e.stopPropagation();
-      toggleTagOnSegment(selectedSegmentId, tags[tagIndex].id);
+      deferSegmentMutation(() => {
+        toggleTagOnSegment(selectedSegmentId, tags[tagIndex].id);
+      });
     };
 
     window.addEventListener("keydown", handler, { capture: true });
@@ -384,7 +402,9 @@ export function useNavigationHotkeys({
     "s",
     () => {
       if (isTranscriptEditing()) return;
-      handleSplitAtCurrentWord();
+      deferSegmentMutation(() => {
+        handleSplitAtCurrentWord();
+      });
     },
     {
       enableOnFormTags: false,
@@ -525,7 +545,9 @@ export function useNavigationHotkeys({
       if (tagIndex >= 0 && tagIndex < tags.length) {
         event.preventDefault();
         event.stopPropagation();
-        toggleTagOnSegment(selectedSegmentId, tags[tagIndex].id);
+        deferSegmentMutation(() => {
+          toggleTagOnSegment(selectedSegmentId, tags[tagIndex].id);
+        });
         tKeyPressedRef.current = false; // Reset flag after successful tag toggle
         if (tKeyTimerRef.current) clearTimeout(tKeyTimerRef.current);
       }


### PR DESCRIPTION
## Summary
- defer segment mutation hotkeys (`s`, `p`, `m`, `b`, `c`, `delete`, `1-9`, `alt+digit`, `t+digit`) to microtasks so keydown handlers return faster and avoid long synchronous keydown work
- keep preventDefault/stopPropagation behavior synchronous while preserving existing merge/split/tag/bookmark/delete semantics
- update `useNavigationHotkeys` tests to await deferred microtask execution for affected hotkeys

## Verification
- `npm run check`
- `npm run lint:fix`
- `npm run check`
- `npm test` (166 files / 1570 tests passed)