### PR TITLE
fix(audio-restore): reconnect audio without replacing session

### DIFF
--- a/client/src/components/FileUpload.tsx
+++ b/client/src/components/FileUpload.tsx
@@ -21,7 +21,7 @@ import { isVTTFormat } from "@/lib/transcriptParsing";
 const logger = createLogger({ feature: "FileUpload", namespace: "UI" });
 
 interface FileUploadProps {
-  onAudioUpload: (file: File) => void;
+  onAudioUpload: (file: File, options?: { mode?: "replace" | "reconnect" }) => void;
   onTranscriptUpload: (data: unknown, reference?: FileReference | null) => void;
   audioFileName?: string;
   transcriptFileName?: string;
@@ -46,6 +46,7 @@ export function FileUpload({
   const audioInputRef = useRef<HTMLInputElement>(null);
   const transcriptInputRef = useRef<HTMLInputElement>(null);
   const [audioHandle, setAudioHandle] = useState<FileSystemFileHandle | null>(null);
+  const pendingAudioModeRef = useRef<"replace" | "reconnect">("replace");
   const [localTranscriptFileName, setLocalTranscriptFileName] = useState<string | undefined>(
     transcriptFileName,
   );
@@ -145,11 +146,13 @@ export function FileUpload({
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
       if (file) {
+        const mode = pendingAudioModeRef.current;
+        pendingAudioModeRef.current = "replace";
         const proceed = confirmIfLargeAudio(file);
         if (!proceed) return;
 
         // Clear handle for old audio if exists
-        if (audioRefKey) {
+        if (audioRefKey && mode !== "reconnect") {
           clearAudioHandleForAudioRef(audioRefKey)
             .then(() => setAudioHandle(null))
             .catch((err) => {
@@ -157,62 +160,70 @@ export function FileUpload({
             });
         }
 
-        onAudioUpload(file);
+        onAudioUpload(file, { mode });
       }
     },
     [onAudioUpload, audioRefKey],
   );
 
-  const handleAudioPick = useCallback(async () => {
-    const picker = (
-      window as Window & {
-        showOpenFilePicker?: (options?: {
-          types?: Array<{
-            description?: string;
-            accept: Record<string, string[]>;
-          }>;
-          multiple?: boolean;
-          excludeAcceptAllOption?: boolean;
-        }) => Promise<FileSystemFileHandle[]>;
+  const handleAudioPick = useCallback(
+    async (mode: "replace" | "reconnect" = "replace") => {
+      const picker = (
+        window as Window & {
+          showOpenFilePicker?: (options?: {
+            types?: Array<{
+              description?: string;
+              accept: Record<string, string[]>;
+            }>;
+            multiple?: boolean;
+            excludeAcceptAllOption?: boolean;
+          }) => Promise<FileSystemFileHandle[]>;
+        }
+      ).showOpenFilePicker;
+
+      if (!picker) {
+        pendingAudioModeRef.current = mode;
+        audioInputRef.current?.click();
+        return;
       }
-    ).showOpenFilePicker;
 
-    if (!picker) {
-      audioInputRef.current?.click();
-      return;
-    }
-
-    try {
-      const [handle] = await picker({
-        multiple: false,
-        types: [
-          {
-            description: t("fileUpload.audioFilesDescription"),
-            accept: {
-              "audio/*": [".mp3", ".wav", ".m4a", ".ogg", ".flac"],
+      try {
+        const [handle] = await picker({
+          multiple: false,
+          types: [
+            {
+              description: t("fileUpload.audioFilesDescription"),
+              accept: {
+                "audio/*": [".mp3", ".wav", ".m4a", ".ogg", ".flac"],
+              },
             },
-          },
-        ],
-      });
-      if (!handle) return;
-      const file = await handle.getFile();
-      const proceed = confirmIfLargeAudio(file);
-      if (!proceed) return;
+          ],
+        });
+        if (!handle) return;
+        const file = await handle.getFile();
+        const proceed = confirmIfLargeAudio(file);
+        if (!proceed) return;
 
-      // Call onAudioUpload FIRST to trigger session creation/change
-      onAudioUpload(file);
+        // Call onAudioUpload FIRST to trigger session creation/change
+        onAudioUpload(file, { mode });
 
-      // Save the handle using the audio reference key
-      // Multiple sessions with the same audio file will share this handle
-      const audioRef = buildFileReference(file);
-      const audioRefKey = buildAudioRefKey(audioRef);
-      await saveAudioHandleForAudioRef(audioRefKey, handle);
-      setAudioHandle(handle);
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      logger.error("Failed to pick audio file.", { error: err });
-    }
-  }, [onAudioUpload, t]);
+        if (mode === "reconnect") {
+          return;
+        }
+
+        // Save the handle using the audio reference key
+        // Multiple sessions with the same audio file will share this handle
+        const audioRef = buildFileReference(file);
+        const audioRefKey = buildAudioRefKey(audioRef);
+        await saveAudioHandleForAudioRef(audioRefKey, handle);
+        setAudioHandle(handle);
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        logger.error("Failed to pick audio file.", { error: err });
+      }
+    },
+    [onAudioUpload, t],
+  );
 
   const handleRestoreAudio = useCallback(async () => {
     if (!audioHandle || !audioRefKey) return;
@@ -229,11 +240,22 @@ export function FileUpload({
           .catch((err) => logger.error("Failed to clear saved audio handle.", { error: err }));
         return;
       }
-      onAudioUpload(file);
+      onAudioUpload(file, { mode: "reconnect" });
     } catch (err) {
       logger.error("Failed to restore audio file.", { error: err });
     }
   }, [audioHandle, onAudioUpload, audioRefKey]);
+
+  const showReconnectAudio =
+    !audioFileName && (audioHandle !== null || transcriptLoaded || audioRef);
+
+  const handleReconnectAudio = useCallback(() => {
+    if (audioHandle) {
+      void handleRestoreAudio();
+      return;
+    }
+    void handleAudioPick("reconnect");
+  }, [audioHandle, handleAudioPick, handleRestoreAudio]);
 
   // confirmIfLargeAudio moved to module scope above to avoid recreating the function on each render
 
@@ -318,7 +340,9 @@ export function FileUpload({
           <TooltipTrigger asChild>
             <Button
               variant={audioFileName ? "secondary" : "default"}
-              onClick={handleAudioPick}
+              onClick={() => {
+                void handleAudioPick("replace");
+              }}
               data-testid="button-upload-audio"
             >
               <FileAudio className="h-4 w-4 mr-2" />
@@ -328,12 +352,12 @@ export function FileUpload({
           <TooltipContent>{t("fileUpload.loadAudioTooltip")}</TooltipContent>
         </Tooltip>
 
-        {!audioFileName && audioHandle && (
+        {showReconnectAudio && (
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
                 variant="outline"
-                onClick={handleRestoreAudio}
+                onClick={handleReconnectAudio}
                 data-testid="button-restore-audio"
               >
                 <RotateCcw className="h-4 w-4 mr-2" />

--- a/client/src/components/FileUpload.tsx
+++ b/client/src/components/FileUpload.tsx
@@ -26,6 +26,7 @@ interface FileUploadProps {
   audioFileName?: string;
   transcriptFileName?: string;
   transcriptLoaded?: boolean;
+  audioRestoreState?: "pending" | "in-progress" | "done" | "failed";
   variant?: "card" | "inline";
   revisionName?: string | null;
 }
@@ -38,6 +39,7 @@ export function FileUpload({
   audioFileName,
   transcriptFileName,
   transcriptLoaded,
+  audioRestoreState,
   variant = "card",
   revisionName,
 }: FileUploadProps) {
@@ -204,17 +206,16 @@ export function FileUpload({
         const proceed = confirmIfLargeAudio(file);
         if (!proceed) return;
 
-        // Call onAudioUpload FIRST to trigger session creation/change
-        onAudioUpload(file, { mode });
+        const effectiveMode = mode === "reconnect" && audioRef === null ? "replace" : mode;
 
-        if (mode === "reconnect") {
-          return;
-        }
+        // Call onAudioUpload FIRST to trigger session creation/change
+        onAudioUpload(file, { mode: effectiveMode });
 
         // Save the handle using the audio reference key
         // Multiple sessions with the same audio file will share this handle
-        const audioRef = buildFileReference(file);
-        const audioRefKey = buildAudioRefKey(audioRef);
+        const referenceForHandle =
+          effectiveMode === "reconnect" && audioRef !== null ? audioRef : buildFileReference(file);
+        const audioRefKey = buildAudioRefKey(referenceForHandle);
         await saveAudioHandleForAudioRef(audioRefKey, handle);
         setAudioHandle(handle);
       } catch (err) {
@@ -222,7 +223,7 @@ export function FileUpload({
         logger.error("Failed to pick audio file.", { error: err });
       }
     },
-    [onAudioUpload, t],
+    [audioRef, onAudioUpload, t],
   );
 
   const handleRestoreAudio = useCallback(async () => {
@@ -246,16 +247,17 @@ export function FileUpload({
     }
   }, [audioHandle, onAudioUpload, audioRefKey]);
 
+  const restoreFailed = audioRestoreState === "failed" || audioRestoreState === undefined;
   const showReconnectAudio =
-    !audioFileName && (audioHandle !== null || transcriptLoaded || audioRef);
+    !audioFileName && restoreFailed && (audioHandle !== null || transcriptLoaded || audioRef);
 
   const handleReconnectAudio = useCallback(() => {
     if (audioHandle) {
       void handleRestoreAudio();
       return;
     }
-    void handleAudioPick("reconnect");
-  }, [audioHandle, handleAudioPick, handleRestoreAudio]);
+    void handleAudioPick(audioRef ? "reconnect" : "replace");
+  }, [audioHandle, audioRef, handleAudioPick, handleRestoreAudio]);
 
   // confirmIfLargeAudio moved to module scope above to avoid recreating the function on each render
 

--- a/client/src/components/__tests__/FileUpload.test.tsx
+++ b/client/src/components/__tests__/FileUpload.test.tsx
@@ -76,7 +76,7 @@ describe("FileUpload", () => {
 
     await userEvent.click(screen.getByTestId("button-upload-audio"));
 
-    await waitFor(() => expect(onAudioUpload).toHaveBeenCalledWith(file));
+    await waitFor(() => expect(onAudioUpload).toHaveBeenCalledWith(file, { mode: "replace" }));
 
     // Handle should be saved with audio reference key
     const audioRef = buildFileReference(file);
@@ -109,7 +109,7 @@ describe("FileUpload", () => {
     const restoreButton = await screen.findByTestId("button-restore-audio");
     await userEvent.click(restoreButton);
 
-    await waitFor(() => expect(onAudioUpload).toHaveBeenCalledWith(file));
+    await waitFor(() => expect(onAudioUpload).toHaveBeenCalledWith(file, { mode: "reconnect" }));
     expect(mockRequestPermission).toHaveBeenCalledWith(handle);
   });
 
@@ -169,7 +169,38 @@ describe("FileUpload", () => {
     fireEvent.change(fileInput, { target: { files: [newFile] } });
 
     expect(mockClearAudioHandle).toHaveBeenCalled();
-    expect(onAudioUpload).toHaveBeenCalledWith(newFile);
+    expect(onAudioUpload).toHaveBeenCalledWith(newFile, { mode: "replace" });
+  });
+
+  it("shows reconnect button without saved handle when transcript is loaded", async () => {
+    render(<FileUpload onAudioUpload={vi.fn()} onTranscriptUpload={vi.fn()} transcriptLoaded />);
+    expect(await screen.findByTestId("button-restore-audio")).toBeInTheDocument();
+  });
+
+  it("reconnect button uses reconnect mode without creating/saving new handle", async () => {
+    const file = new File(["audio"], "manual-reconnect.mp3", { type: "audio/mpeg" });
+    const handle = {
+      getFile: vi.fn().mockResolvedValue(file),
+    } as unknown as FileSystemFileHandle;
+    const showOpenFilePicker = vi.fn().mockResolvedValue([handle]);
+    Object.defineProperty(window, "showOpenFilePicker", {
+      value: showOpenFilePicker,
+      writable: true,
+    });
+
+    const onAudioUpload = vi.fn();
+    render(
+      <FileUpload onAudioUpload={onAudioUpload} onTranscriptUpload={vi.fn()} transcriptLoaded />,
+    );
+
+    await userEvent.click(await screen.findByTestId("button-restore-audio"));
+
+    await waitFor(() => {
+      expect(onAudioUpload).toHaveBeenCalledWith(file, { mode: "reconnect" });
+    });
+    expect(mockSaveAudioHandle).not.toHaveBeenCalled();
+
+    (window as { showOpenFilePicker?: unknown }).showOpenFilePicker = undefined;
   });
 
   it("uses transcript file picker and passes VTT content through", async () => {

--- a/client/src/components/__tests__/FileUpload.test.tsx
+++ b/client/src/components/__tests__/FileUpload.test.tsx
@@ -177,7 +177,7 @@ describe("FileUpload", () => {
     expect(await screen.findByTestId("button-restore-audio")).toBeInTheDocument();
   });
 
-  it("reconnect button uses reconnect mode without creating/saving new handle", async () => {
+  it("reconnect fallback without audioRef uses replace mode and saves handle", async () => {
     const file = new File(["audio"], "manual-reconnect.mp3", { type: "audio/mpeg" });
     const handle = {
       getFile: vi.fn().mockResolvedValue(file),
@@ -196,9 +196,40 @@ describe("FileUpload", () => {
     await userEvent.click(await screen.findByTestId("button-restore-audio"));
 
     await waitFor(() => {
+      expect(onAudioUpload).toHaveBeenCalledWith(file, { mode: "replace" });
+    });
+    expect(mockSaveAudioHandle).toHaveBeenCalledTimes(1);
+
+    (window as { showOpenFilePicker?: unknown }).showOpenFilePicker = undefined;
+  });
+
+  it("reconnect fallback with audioRef uses reconnect mode and saves handle to audioRef key", async () => {
+    const file = new File(["audio"], "manual-reconnect.mp3", { type: "audio/mpeg" });
+    const existingRef = buildFileReference(file);
+    mockAudioRef = existingRef;
+    const expectedAudioRefKey = JSON.stringify({
+      name: existingRef.name,
+      size: existingRef.size,
+      lastModified: existingRef.lastModified,
+    });
+    const handle = {
+      getFile: vi.fn().mockResolvedValue(file),
+    } as unknown as FileSystemFileHandle;
+    const showOpenFilePicker = vi.fn().mockResolvedValue([handle]);
+    Object.defineProperty(window, "showOpenFilePicker", {
+      value: showOpenFilePicker,
+      writable: true,
+    });
+
+    const onAudioUpload = vi.fn();
+    render(<FileUpload onAudioUpload={onAudioUpload} onTranscriptUpload={vi.fn()} />);
+
+    await userEvent.click(await screen.findByTestId("button-restore-audio"));
+
+    await waitFor(() => {
       expect(onAudioUpload).toHaveBeenCalledWith(file, { mode: "reconnect" });
     });
-    expect(mockSaveAudioHandle).not.toHaveBeenCalled();
+    expect(mockSaveAudioHandle).toHaveBeenCalledWith(expectedAudioRefKey, handle);
 
     (window as { showOpenFilePicker?: unknown }).showOpenFilePicker = undefined;
   });

--- a/client/src/components/transcript-editor/Toolbar.tsx
+++ b/client/src/components/transcript-editor/Toolbar.tsx
@@ -49,6 +49,7 @@ export function Toolbar({
   audioFileName,
   transcriptFileName,
   transcriptLoaded,
+  audioRestoreState,
   sessionKind,
   sessionLabel,
   activeSessionKey,
@@ -155,6 +156,7 @@ export function Toolbar({
               audioFileName={audioFileName}
               transcriptFileName={transcriptFileName}
               transcriptLoaded={transcriptLoaded}
+              audioRestoreState={audioRestoreState}
               revisionName={revisionName}
               variant="inline"
             />

--- a/client/src/components/transcript-editor/__tests__/Toolbar.test.tsx
+++ b/client/src/components/transcript-editor/__tests__/Toolbar.test.tsx
@@ -63,6 +63,7 @@ const baseProps: TranscriptEditorState["toolbarProps"] = {
   aiCommandPanelOpen: false,
   onToggleAICommandPanel: vi.fn(),
   onOpenSettings: vi.fn(),
+  audioRestoreState: "done" as const,
 };
 
 describe("Toolbar", () => {

--- a/client/src/components/transcript-editor/__tests__/useTranscriptInitialization.test.ts
+++ b/client/src/components/transcript-editor/__tests__/useTranscriptInitialization.test.ts
@@ -423,4 +423,41 @@ describe("useTranscriptInitialization", () => {
     });
     expect(reconnectAudio).not.toHaveBeenCalled();
   });
+
+  it("tries audio restore again when the audio reference changes", async () => {
+    const missingFile = new File(["missing"], "missing.wav", { type: "audio/wav" });
+    const restoredFile = new File(["restored"], "restored.wav", { type: "audio/wav" });
+    const missingRef = buildFileReference(missingFile);
+    const restoredRef = buildFileReference(restoredFile);
+    const handle = { getFile: vi.fn().mockResolvedValue(restoredFile) };
+    mockLoadAudioHandle.mockResolvedValueOnce(null).mockResolvedValueOnce(handle);
+    mockQueryAudioHandlePermission.mockResolvedValue(true);
+
+    const { rerender, result } = renderHook(
+      ({ audioRef }) =>
+        useTranscriptInitialization({
+          audioFile: null,
+          audioUrl: null,
+          audioRef,
+          duration: 0,
+          setAudioFile,
+          setAudioUrl,
+          setAudioReference,
+          reconnectAudio,
+          loadTranscript,
+        }),
+      { initialProps: { audioRef: missingRef } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.audioRestoreState).toBe("failed");
+    });
+
+    rerender({ audioRef: restoredRef });
+
+    await waitFor(() => {
+      expect(reconnectAudio).toHaveBeenCalledWith(restoredFile);
+    });
+    expect(result.current.audioRestoreState).toBe("done");
+  });
 });

--- a/client/src/components/transcript-editor/__tests__/useTranscriptInitialization.test.ts
+++ b/client/src/components/transcript-editor/__tests__/useTranscriptInitialization.test.ts
@@ -73,7 +73,6 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef: null,
         duration: 0,
-        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -101,7 +100,6 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef,
         duration: 0,
-        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -130,7 +128,6 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef,
         duration: 0,
-        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -147,15 +144,14 @@ describe("useTranscriptInitialization", () => {
     expect(setAudioReference).not.toHaveBeenCalled();
   });
 
-  it("uses reconnectAudio when session content exists but audioRef is missing", () => {
-    const file = new File(["audio"], "session-reconnect.mp3", { type: "audio/mpeg" });
+  it("uses setAudioReference when mode is replace and audioRef is missing", () => {
+    const file = new File(["audio"], "session-replace.mp3", { type: "audio/mpeg" });
     const { result } = renderHook(() =>
       useTranscriptInitialization({
         audioFile: null,
         audioUrl: null,
         audioRef: null,
         duration: 0,
-        hasSessionContent: true,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -165,14 +161,16 @@ describe("useTranscriptInitialization", () => {
     );
 
     act(() => {
-      result.current.handleAudioUpload(file);
+      result.current.handleAudioUpload(file, { mode: "replace" });
     });
 
-    expect(reconnectAudio).toHaveBeenCalledWith(file);
-    expect(setAudioReference).not.toHaveBeenCalled();
+    expect(reconnectAudio).not.toHaveBeenCalled();
+    expect(setAudioReference).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "session-replace.mp3" }),
+    );
   });
 
-  it("supports forced reconnect mode for manual reattach", () => {
+  it("falls back to replace when forced reconnect is used without audioRef", () => {
     const file = new File(["audio"], "force-reconnect.mp3", { type: "audio/mpeg" });
     const { result } = renderHook(() =>
       useTranscriptInitialization({
@@ -180,7 +178,6 @@ describe("useTranscriptInitialization", () => {
         audioUrl: "blob:existing-url",
         audioRef: null,
         duration: 0,
-        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -193,8 +190,10 @@ describe("useTranscriptInitialization", () => {
       result.current.handleAudioUpload(file, { mode: "reconnect" });
     });
 
-    expect(reconnectAudio).toHaveBeenCalledWith(file);
-    expect(setAudioReference).not.toHaveBeenCalled();
+    expect(reconnectAudio).not.toHaveBeenCalled();
+    expect(setAudioReference).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "force-reconnect.mp3" }),
+    );
   });
 
   it("uses setAudioReference (not reconnectAudio) when audio is already loaded (swap case)", () => {
@@ -206,7 +205,6 @@ describe("useTranscriptInitialization", () => {
         audioUrl: "blob:existing-url",
         audioRef,
         duration: 0,
-        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -226,7 +224,12 @@ describe("useTranscriptInitialization", () => {
   });
 
   it("parses transcript uploads and loads transcript", () => {
-    const parsed = { segments: [{ id: "a" }], isWhisperXFormat: false };
+    const parsed = {
+      segments: [{ id: "a" }],
+      isWhisperXFormat: false,
+      tags: undefined,
+      chapters: undefined,
+    };
     mockParseTranscriptData.mockReturnValue(parsed);
     const reference = { name: "transcript.json" };
     const { result } = renderHook(() =>
@@ -235,7 +238,6 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef: null,
         duration: 0,
-        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -270,7 +272,6 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef,
         duration: 0,
-        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -298,7 +299,6 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef,
         duration: 0,
-        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -330,7 +330,6 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef,
         duration: 0,
-        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -344,6 +343,84 @@ describe("useTranscriptInitialization", () => {
     });
     expect(setAudioFile).not.toHaveBeenCalled();
     expect(setAudioUrl).not.toHaveBeenCalled();
+    expect(reconnectAudio).not.toHaveBeenCalled();
+  });
+
+  it("audioRestoreState transitions to 'done' after successful restore", async () => {
+    const restoredFile = new File(["audio"], "restored.wav", { type: "audio/wav" });
+    const audioRef = buildFileReference(restoredFile);
+    mockLoadAudioHandle.mockResolvedValue({ getFile: vi.fn().mockResolvedValue(restoredFile) });
+    mockQueryAudioHandlePermission.mockResolvedValue(true);
+
+    const { result } = renderHook(() =>
+      useTranscriptInitialization({
+        audioFile: null,
+        audioUrl: null,
+        audioRef,
+        duration: 0,
+        setAudioFile,
+        setAudioUrl,
+        setAudioReference,
+        reconnectAudio,
+        loadTranscript,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.audioRestoreState).toBe("done");
+    });
+    expect(reconnectAudio).toHaveBeenCalledWith(restoredFile);
+  });
+
+  it("audioRestoreState transitions to 'failed' when no handle is stored", async () => {
+    const restoredFile = new File(["audio"], "nohandle.wav", { type: "audio/wav" });
+    const audioRef = buildFileReference(restoredFile);
+    mockLoadAudioHandle.mockResolvedValue(null);
+
+    const { result } = renderHook(() =>
+      useTranscriptInitialization({
+        audioFile: null,
+        audioUrl: null,
+        audioRef,
+        duration: 0,
+        setAudioFile,
+        setAudioUrl,
+        setAudioReference,
+        reconnectAudio,
+        loadTranscript,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.audioRestoreState).toBe("failed");
+    });
+    expect(reconnectAudio).not.toHaveBeenCalled();
+  });
+
+  it("audioRestoreState transitions to 'failed' when permission is denied", async () => {
+    const restoredFile = new File(["audio"], "noperm.wav", { type: "audio/wav" });
+    const audioRef = buildFileReference(restoredFile);
+    const handle = { getFile: vi.fn().mockResolvedValue(restoredFile) };
+    mockLoadAudioHandle.mockResolvedValue(handle);
+    mockQueryAudioHandlePermission.mockResolvedValue(false);
+
+    const { result } = renderHook(() =>
+      useTranscriptInitialization({
+        audioFile: null,
+        audioUrl: null,
+        audioRef,
+        duration: 0,
+        setAudioFile,
+        setAudioUrl,
+        setAudioReference,
+        reconnectAudio,
+        loadTranscript,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.audioRestoreState).toBe("failed");
+    });
     expect(reconnectAudio).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/transcript-editor/__tests__/useTranscriptInitialization.test.ts
+++ b/client/src/components/transcript-editor/__tests__/useTranscriptInitialization.test.ts
@@ -73,6 +73,7 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef: null,
         duration: 0,
+        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -100,6 +101,7 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef,
         duration: 0,
+        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -128,6 +130,7 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef,
         duration: 0,
+        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -144,6 +147,56 @@ describe("useTranscriptInitialization", () => {
     expect(setAudioReference).not.toHaveBeenCalled();
   });
 
+  it("uses reconnectAudio when session content exists but audioRef is missing", () => {
+    const file = new File(["audio"], "session-reconnect.mp3", { type: "audio/mpeg" });
+    const { result } = renderHook(() =>
+      useTranscriptInitialization({
+        audioFile: null,
+        audioUrl: null,
+        audioRef: null,
+        duration: 0,
+        hasSessionContent: true,
+        setAudioFile,
+        setAudioUrl,
+        setAudioReference,
+        reconnectAudio,
+        loadTranscript,
+      }),
+    );
+
+    act(() => {
+      result.current.handleAudioUpload(file);
+    });
+
+    expect(reconnectAudio).toHaveBeenCalledWith(file);
+    expect(setAudioReference).not.toHaveBeenCalled();
+  });
+
+  it("supports forced reconnect mode for manual reattach", () => {
+    const file = new File(["audio"], "force-reconnect.mp3", { type: "audio/mpeg" });
+    const { result } = renderHook(() =>
+      useTranscriptInitialization({
+        audioFile: null,
+        audioUrl: "blob:existing-url",
+        audioRef: null,
+        duration: 0,
+        hasSessionContent: false,
+        setAudioFile,
+        setAudioUrl,
+        setAudioReference,
+        reconnectAudio,
+        loadTranscript,
+      }),
+    );
+
+    act(() => {
+      result.current.handleAudioUpload(file, { mode: "reconnect" });
+    });
+
+    expect(reconnectAudio).toHaveBeenCalledWith(file);
+    expect(setAudioReference).not.toHaveBeenCalled();
+  });
+
   it("uses setAudioReference (not reconnectAudio) when audio is already loaded (swap case)", () => {
     const file = new File(["audio"], "new-audio.wav", { type: "audio/wav" });
     const audioRef = buildFileReference(new File(["old"], "old-audio.wav", { type: "audio/wav" }));
@@ -153,6 +206,7 @@ describe("useTranscriptInitialization", () => {
         audioUrl: "blob:existing-url",
         audioRef,
         duration: 0,
+        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -181,6 +235,7 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef: null,
         duration: 0,
+        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -215,6 +270,7 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef,
         duration: 0,
+        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -242,6 +298,7 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef,
         duration: 0,
+        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,
@@ -273,6 +330,7 @@ describe("useTranscriptInitialization", () => {
         audioUrl: null,
         audioRef,
         duration: 0,
+        hasSessionContent: false,
         setAudioFile,
         setAudioUrl,
         setAudioReference,

--- a/client/src/components/transcript-editor/useTranscriptEditor.ts
+++ b/client/src/components/transcript-editor/useTranscriptEditor.ts
@@ -197,7 +197,7 @@ export const useTranscriptEditor = () => {
     setSpellcheckCustomEnabled,
   } = transcriptActions;
 
-  const { handleAudioUpload, handleTranscriptUpload, handleWaveReady } =
+  const { handleAudioUpload, handleTranscriptUpload, handleWaveReady, audioRestoreState } =
     useTranscriptInitialization({
       audioFile,
       audioUrl,
@@ -208,7 +208,6 @@ export const useTranscriptEditor = () => {
       setAudioReference,
       reconnectAudio,
       loadTranscript,
-      hasSessionContent: segments.length > 0 || transcriptRef !== null,
     });
 
   const canUndoChecked = canUndo();
@@ -710,6 +709,7 @@ export const useTranscriptEditor = () => {
     audioFileName: audioFile?.name,
     transcriptFileName: transcriptRef?.name,
     transcriptLoaded: segments.length > 0,
+    audioRestoreState,
     sessionKind,
     sessionLabel,
     activeSessionKey: sessionKey,

--- a/client/src/components/transcript-editor/useTranscriptEditor.ts
+++ b/client/src/components/transcript-editor/useTranscriptEditor.ts
@@ -208,6 +208,7 @@ export const useTranscriptEditor = () => {
       setAudioReference,
       reconnectAudio,
       loadTranscript,
+      hasSessionContent: segments.length > 0 || transcriptRef !== null,
     });
 
   const canUndoChecked = canUndo();

--- a/client/src/components/transcript-editor/useTranscriptInitialization.ts
+++ b/client/src/components/transcript-editor/useTranscriptInitialization.ts
@@ -32,6 +32,7 @@ interface UseTranscriptInitializationParams {
     chapters?: Chapter[] | undefined;
     reference: FileReference | null;
   }) => void;
+  hasSessionContent: boolean;
 }
 
 export const useTranscriptInitialization = ({
@@ -44,6 +45,7 @@ export const useTranscriptInitialization = ({
   setAudioReference,
   reconnectAudio,
   loadTranscript,
+  hasSessionContent,
 }: UseTranscriptInitializationParams) => {
   const { t } = useTranslation();
   const { toast } = useToast();
@@ -53,12 +55,14 @@ export const useTranscriptInitialization = ({
   const restoreAttemptedRef = useRef(false);
 
   const handleAudioUpload = useCallback(
-    (file: File) => {
+    (file: File, options?: { mode?: "replace" | "reconnect" }) => {
       // If a session with transcript data already exists but no audio is loaded
       // (e.g. after a backup restore + page reload), reconnect without resetting
       // transcript state. In all other cases use the normal path which resets the
       // transcript when a new audio file is introduced.
-      const isReconnect = audioUrl === null && audioRef !== null;
+      const isReconnect =
+        options?.mode === "reconnect" ||
+        (audioUrl === null && (audioRef !== null || hasSessionContent));
       if (isReconnect) {
         reconnectAudio(file);
       } else {
@@ -68,7 +72,15 @@ export const useTranscriptInitialization = ({
         setAudioReference(buildFileReference(file));
       }
     },
-    [audioRef, audioUrl, reconnectAudio, setAudioFile, setAudioReference, setAudioUrl],
+    [
+      audioRef,
+      audioUrl,
+      hasSessionContent,
+      reconnectAudio,
+      setAudioFile,
+      setAudioReference,
+      setAudioUrl,
+    ],
   );
 
   const handleTranscriptUpload = useCallback(

--- a/client/src/components/transcript-editor/useTranscriptInitialization.ts
+++ b/client/src/components/transcript-editor/useTranscriptInitialization.ts
@@ -1,4 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+
+type AudioRestoreState = "pending" | "in-progress" | "done" | "failed";
+
 import { useTranslation } from "react-i18next";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -32,7 +35,6 @@ interface UseTranscriptInitializationParams {
     chapters?: Chapter[] | undefined;
     reference: FileReference | null;
   }) => void;
-  hasSessionContent: boolean;
 }
 
 export const useTranscriptInitialization = ({
@@ -45,7 +47,6 @@ export const useTranscriptInitialization = ({
   setAudioReference,
   reconnectAudio,
   loadTranscript,
-  hasSessionContent,
 }: UseTranscriptInitializationParams) => {
   const { t } = useTranslation();
   const { toast } = useToast();
@@ -53,6 +54,13 @@ export const useTranscriptInitialization = ({
   const audioRefKey = audioRef ? buildAudioRefKey(audioRef) : null;
   const [isWaveReady, setIsWaveReady] = useState(!audioUrl);
   const restoreAttemptedRef = useRef(false);
+  // "pending"     — we haven't tried yet (audioRefKey not yet known, or effect not run)
+  // "in-progress" — async restore is running
+  // "done"        — restore succeeded (or no handle was needed)
+  // "failed"      — handle missing / permission denied → show Reopen button
+  const [audioRestoreState, setAudioRestoreState] = useState<AudioRestoreState>(
+    audioRefKey ? "pending" : "done",
+  );
 
   const handleAudioUpload = useCallback(
     (file: File, options?: { mode?: "replace" | "reconnect" }) => {
@@ -61,8 +69,8 @@ export const useTranscriptInitialization = ({
       // transcript state. In all other cases use the normal path which resets the
       // transcript when a new audio file is introduced.
       const isReconnect =
-        options?.mode === "reconnect" ||
-        (audioUrl === null && (audioRef !== null || hasSessionContent));
+        (options?.mode === "reconnect" && audioRef !== null) ||
+        (options?.mode !== "replace" && audioUrl === null && audioRef !== null);
       if (isReconnect) {
         reconnectAudio(file);
       } else {
@@ -72,15 +80,7 @@ export const useTranscriptInitialization = ({
         setAudioReference(buildFileReference(file));
       }
     },
-    [
-      audioRef,
-      audioUrl,
-      hasSessionContent,
-      reconnectAudio,
-      setAudioFile,
-      setAudioReference,
-      setAudioUrl,
-    ],
+    [audioRef, audioUrl, reconnectAudio, setAudioFile, setAudioReference, setAudioUrl],
   );
 
   const handleTranscriptUpload = useCallback(
@@ -136,26 +136,35 @@ export const useTranscriptInitialization = ({
     restoreAttemptedRef.current = true;
     let isMounted = true;
 
+    setAudioRestoreState("in-progress");
+
     loadAudioHandleForAudioRef(audioRefKey)
       .then(async (handle) => {
-        if (!handle || !isMounted) return;
+        if (!handle || !isMounted) {
+          if (isMounted) setAudioRestoreState("failed");
+          return;
+        }
         const granted = await queryAudioHandlePermission(handle);
-        if (!granted || !isMounted) return;
+        if (!granted || !isMounted) {
+          if (isMounted) setAudioRestoreState("failed");
+          return;
+        }
         const file = await handle.getFile();
         if (!isMounted) return;
         const proceed = confirmIfLargeAudio(file);
         if (!proceed) {
-          // User declined loading the previously saved large file after reload.
-          // Clear the stored handle for this audio to avoid repeatedly prompting.
           clearAudioHandleForAudioRef(audioRefKey).catch((err) =>
             logger.error("Failed to clear saved audio handle.", { error: err }),
           );
+          if (isMounted) setAudioRestoreState("failed");
           return;
         }
         handleAudioUpload(file);
+        if (isMounted) setAudioRestoreState("done");
       })
       .catch((err) => {
         logger.error("Failed to restore audio handle.", { error: err });
+        if (isMounted) setAudioRestoreState("failed");
       });
 
     return () => {
@@ -176,6 +185,7 @@ export const useTranscriptInitialization = ({
     handleTranscriptUpload,
     handleWaveReady,
     isWaveReady,
+    audioRestoreState,
   };
 };
 

--- a/client/src/components/transcript-editor/useTranscriptInitialization.ts
+++ b/client/src/components/transcript-editor/useTranscriptInitialization.ts
@@ -53,11 +53,9 @@ export const useTranscriptInitialization = ({
   // Compute audio reference key for handle storage
   const audioRefKey = audioRef ? buildAudioRefKey(audioRef) : null;
   const [isWaveReady, setIsWaveReady] = useState(!audioUrl);
-  const restoreAttemptedRef = useRef(false);
-  // "pending"     — we haven't tried yet (audioRefKey not yet known, or effect not run)
-  // "in-progress" — async restore is running
-  // "done"        — restore succeeded (or no handle was needed)
-  // "failed"      — handle missing / permission denied → show Reopen button
+  const restoreAttemptedAudioRefKeyRef = useRef<string | null>(null);
+  // "pending" means the audio ref is known but restore has not run yet.
+  // "failed" means the UI should offer manual reconnect.
   const [audioRestoreState, setAudioRestoreState] = useState<AudioRestoreState>(
     audioRefKey ? "pending" : "done",
   );
@@ -79,6 +77,7 @@ export const useTranscriptInitialization = ({
         setAudioUrl(url);
         setAudioReference(buildFileReference(file));
       }
+      setAudioRestoreState("done");
     },
     [audioRef, audioUrl, reconnectAudio, setAudioFile, setAudioReference, setAudioUrl],
   );
@@ -132,8 +131,12 @@ export const useTranscriptInitialization = ({
   );
 
   useEffect(() => {
-    if (restoreAttemptedRef.current || audioFile || !audioRefKey) return;
-    restoreAttemptedRef.current = true;
+    if (audioFile || !audioRefKey) {
+      setAudioRestoreState("done");
+      return;
+    }
+    if (restoreAttemptedAudioRefKeyRef.current === audioRefKey) return;
+    restoreAttemptedAudioRefKeyRef.current = audioRefKey;
     let isMounted = true;
 
     setAudioRestoreState("in-progress");


### PR DESCRIPTION
## Summary
- keep transcript sessions stable when audio is reattached after reload
- show reconnect action when automatic audio restore cannot use a saved handle
- use permission query before restoring saved audio handles

## Verification
- npm run check
- npm run lint
- npm test