### PR TITLE
fix(store): avoid crypto.randomUUID dependency for tag ids

### DIFF
--- a/client/src/lib/__tests__/store.id.test.ts
+++ b/client/src/lib/__tests__/store.id.test.ts
@@ -32,4 +32,52 @@ describe("Id generation", () => {
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
     );
   });
+
+  it("adds tags when crypto.randomUUID is unavailable", () => {
+    vi.stubGlobal("crypto", {
+      getRandomValues: (buffer: Uint8Array) => {
+        for (let i = 0; i < buffer.length; i += 1) {
+          buffer[i] = (i * 17) % 256;
+        }
+        return buffer;
+      },
+    });
+
+    expect(() => useTranscriptStore.getState().addTag("Production")).not.toThrow();
+
+    const { tags } = useTranscriptStore.getState();
+    expect(tags).toHaveLength(1);
+    expect(tags[0]?.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("imports transcript tags when crypto.randomUUID is unavailable", () => {
+    vi.stubGlobal("crypto", {
+      getRandomValues: (buffer: Uint8Array) => {
+        for (let i = 0; i < buffer.length; i += 1) {
+          buffer[i] = (i * 13) % 256;
+        }
+        return buffer;
+      },
+    });
+
+    expect(() =>
+      useTranscriptStore.getState().loadTranscript({
+        segments: [
+          {
+            ...sampleSegments[0],
+            tags: ["Interview"],
+          },
+        ],
+      }),
+    ).not.toThrow();
+
+    const { tags } = useTranscriptStore.getState();
+    expect(tags).toHaveLength(1);
+    expect(tags[0]?.name).toBe("Interview");
+    expect(tags[0]?.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
 });

--- a/client/src/lib/store/slices/segmentsSlice.ts
+++ b/client/src/lib/store/slices/segmentsSlice.ts
@@ -190,7 +190,7 @@ export const createSegmentsSlice = (
 
     let fallbackColorIndex = 0;
     const importedTags = incomingTagNames.map((name) => ({
-      id: crypto.randomUUID(),
+      id: generateId(),
       name,
       color:
         incomingTagColors.get(name) ?? SPEAKER_COLORS[fallbackColorIndex++ % SPEAKER_COLORS.length],

--- a/client/src/lib/store/slices/tagsSlice.ts
+++ b/client/src/lib/store/slices/tagsSlice.ts
@@ -1,6 +1,7 @@
 import type { StoreApi } from "zustand";
 import { SPEAKER_COLORS } from "../constants";
 import type { Segment, Tag, TagsSlice, TranscriptStore } from "../types";
+import { generateId } from "../utils/id";
 import { getSegmentTags } from "../utils/segmentTags";
 import { addToHistory } from "./historySlice";
 
@@ -37,7 +38,7 @@ export const createTagsSlice = (set: StoreSetter, get: StoreGetter): TagsSlice =
     if (exists) return false;
 
     const newTag: Tag = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       name: normalized,
       color: SPEAKER_COLORS[tags.length % SPEAKER_COLORS.length],
     };


### PR DESCRIPTION
## Summary
- use generateId for tag IDs in tag creation and transcript import
- cover environments where crypto.randomUUID is unavailable

## Verification
- npm run check
- npm run lint
- npm test