### PR TITLE
fix(backup): stop dirty-unload recovery loop

### DIFF
--- a/client/src/components/backup/DirtyUnloadBanner.tsx
+++ b/client/src/components/backup/DirtyUnloadBanner.tsx
@@ -67,12 +67,6 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
     }, 4000);
   }, []);
 
-  const showError = useCallback((message: string) => {
-    clearDirtyUnloadFlag();
-    setErrorMsg(message);
-    setPhase("error");
-  }, []);
-
   const handleDismiss = useCallback(() => {
     clearDirtyUnloadFlag();
     setPhase("hidden");
@@ -85,7 +79,8 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
     const scheduler = (window as Window & { __backupScheduler?: BackupScheduler })
       .__backupScheduler;
     if (!scheduler) {
-      showError(t("backup.dirtyUnload.schedulerUnavailable"));
+      setErrorMsg(t("backup.dirtyUnload.schedulerUnavailable"));
+      setPhase("error");
       return;
     }
     await scheduler.backupNow("before-unload");
@@ -96,9 +91,10 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
       setPhase("success");
       scheduleAutoDismiss();
     } else {
-      showError(err);
+      setErrorMsg(err);
+      setPhase("error");
     }
-  }, [scheduleAutoDismiss, showError, t]);
+  }, [scheduleAutoDismiss, t]);
 
   const handlePermissionNeeded = useCallback(async () => {
     setPhase("saving");
@@ -107,7 +103,8 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
     const scheduler = (window as Window & { __backupScheduler?: BackupScheduler })
       .__backupScheduler;
     if (!scheduler) {
-      showError(t("backup.dirtyUnload.schedulerUnavailable"));
+      setErrorMsg(t("backup.dirtyUnload.schedulerUnavailable"));
+      setPhase("error");
       return;
     }
 
@@ -119,7 +116,8 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
       const result = await scheduler.reauthorize();
 
       if (!result.ok) {
-        showError(result.error);
+        setErrorMsg(result.error);
+        setPhase("error");
         return;
       }
 
@@ -131,12 +129,14 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
         setPhase("success");
         scheduleAutoDismiss();
       } else {
-        showError(err);
+        setErrorMsg(err);
+        setPhase("error");
       }
     } catch (e) {
-      showError(e instanceof Error ? e.message : String(e));
+      setErrorMsg(e instanceof Error ? e.message : String(e));
+      setPhase("error");
     }
-  }, [scheduleAutoDismiss, showError, t]);
+  }, [scheduleAutoDismiss, t]);
 
   const handleNoBackup = useCallback(() => {
     onOpenSettings?.("backup");

--- a/client/src/components/backup/DirtyUnloadBanner.tsx
+++ b/client/src/components/backup/DirtyUnloadBanner.tsx
@@ -67,6 +67,12 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
     }, 4000);
   }, []);
 
+  const showError = useCallback((message: string) => {
+    clearDirtyUnloadFlag();
+    setErrorMsg(message);
+    setPhase("error");
+  }, []);
+
   const handleDismiss = useCallback(() => {
     clearDirtyUnloadFlag();
     setPhase("hidden");
@@ -79,8 +85,7 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
     const scheduler = (window as Window & { __backupScheduler?: BackupScheduler })
       .__backupScheduler;
     if (!scheduler) {
-      setErrorMsg(t("backup.dirtyUnload.schedulerUnavailable"));
-      setPhase("error");
+      showError(t("backup.dirtyUnload.schedulerUnavailable"));
       return;
     }
     await scheduler.backupNow("before-unload");
@@ -91,10 +96,9 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
       setPhase("success");
       scheduleAutoDismiss();
     } else {
-      setErrorMsg(err);
-      setPhase("error");
+      showError(err);
     }
-  }, [scheduleAutoDismiss, t]);
+  }, [scheduleAutoDismiss, showError, t]);
 
   const handlePermissionNeeded = useCallback(async () => {
     setPhase("saving");
@@ -103,8 +107,7 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
     const scheduler = (window as Window & { __backupScheduler?: BackupScheduler })
       .__backupScheduler;
     if (!scheduler) {
-      setErrorMsg(t("backup.dirtyUnload.schedulerUnavailable"));
-      setPhase("error");
+      showError(t("backup.dirtyUnload.schedulerUnavailable"));
       return;
     }
 
@@ -116,8 +119,7 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
       const result = await scheduler.reauthorize();
 
       if (!result.ok) {
-        setErrorMsg(result.error);
-        setPhase("error");
+        showError(result.error);
         return;
       }
 
@@ -129,18 +131,22 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
         setPhase("success");
         scheduleAutoDismiss();
       } else {
-        setErrorMsg(err);
-        setPhase("error");
+        showError(err);
       }
     } catch (e) {
-      setErrorMsg(e instanceof Error ? e.message : String(e));
-      setPhase("error");
+      showError(e instanceof Error ? e.message : String(e));
     }
-  }, [scheduleAutoDismiss, t]);
+  }, [scheduleAutoDismiss, showError, t]);
 
   const handleNoBackup = useCallback(() => {
     onOpenSettings?.("backup");
     clearDirtyUnloadFlag();
+    setPhase("hidden");
+  }, [onOpenSettings]);
+
+  const handleOpenBackupSettings = useCallback(() => {
+    clearDirtyUnloadFlag();
+    onOpenSettings?.("backup");
     setPhase("hidden");
   }, [onOpenSettings]);
 
@@ -178,9 +184,24 @@ export function DirtyUnloadBanner({ onOpenSettings }: DirtyUnloadBannerProps) {
         </div>
 
         {phase === "error" && errorMsg && (
-          <div className="flex items-center gap-2 text-sm text-destructive">
-            <AlertCircle className="h-4 w-4 shrink-0" />
-            <span>{t("backup.dirtyUnload.errorMessage", { error: errorMsg })}</span>
+          <div className="flex flex-col gap-2 text-sm text-destructive">
+            <div className="flex items-center gap-2">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <span>{t("backup.dirtyUnload.errorMessage", { error: errorMsg })}</span>
+            </div>
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <span>{t("backup.dirtyUnload.reconnectHint")}</span>
+              {onOpenSettings && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto p-0 underline"
+                  onClick={handleOpenBackupSettings}
+                >
+                  {t("backup.dirtyUnload.openBackupSettingsButton")}
+                </Button>
+              )}
+            </div>
           </div>
         )}
 

--- a/client/src/components/backup/__tests__/DirtyUnloadBanner.test.tsx
+++ b/client/src/components/backup/__tests__/DirtyUnloadBanner.test.tsx
@@ -145,7 +145,7 @@ describe("DirtyUnloadBanner", () => {
     expect(mockClearFlag).toHaveBeenCalled();
   });
 
-  it("variant A: clears flag after backup failure so the banner does not loop", async () => {
+  it("variant A: shows error message and does NOT clear flag when backup fails", async () => {
     setFlagPresent();
     setBackupEnabled("enabled");
     // Simulate backup failure by setting lastError in store after backupNow
@@ -171,7 +171,7 @@ describe("DirtyUnloadBanner", () => {
     await waitFor(() => {
       expect(screen.getByText(/Backup failed/)).toBeInTheDocument();
     });
-    expect(mockClearFlag).toHaveBeenCalled();
+    expect(mockClearFlag).not.toHaveBeenCalled();
   });
 
   it("variant A: shows error when scheduler is not available", async () => {
@@ -194,7 +194,7 @@ describe("DirtyUnloadBanner", () => {
       expect(screen.getByText(/Backup failed/)).toBeInTheDocument();
     });
     expect(mockBackupNow).not.toHaveBeenCalled();
-    expect(mockClearFlag).toHaveBeenCalled();
+    expect(mockClearFlag).not.toHaveBeenCalled();
   });
 
   it("dismiss button clears flag and hides banner", async () => {
@@ -376,7 +376,7 @@ describe("DirtyUnloadBanner", () => {
     });
     expect(mockReauthorize).toHaveBeenCalled();
     expect(mockBackupNow).not.toHaveBeenCalled();
-    expect(mockClearFlag).toHaveBeenCalled();
+    expect(mockClearFlag).not.toHaveBeenCalled();
   });
 
   it("variant B: shows error when scheduler is not available", async () => {
@@ -398,7 +398,7 @@ describe("DirtyUnloadBanner", () => {
       expect(screen.getByText(/Backup failed/)).toBeInTheDocument();
     });
     expect(mockReauthorize).not.toHaveBeenCalled();
-    expect(mockClearFlag).toHaveBeenCalled();
+    expect(mockClearFlag).not.toHaveBeenCalled();
   });
 
   it("Bug B: banner does NOT re-appear after dismiss when backupState.status changes", async () => {

--- a/client/src/components/backup/__tests__/DirtyUnloadBanner.test.tsx
+++ b/client/src/components/backup/__tests__/DirtyUnloadBanner.test.tsx
@@ -145,7 +145,7 @@ describe("DirtyUnloadBanner", () => {
     expect(mockClearFlag).toHaveBeenCalled();
   });
 
-  it("variant A: shows error message and does NOT clear flag when backup fails", async () => {
+  it("variant A: clears flag after backup failure so the banner does not loop", async () => {
     setFlagPresent();
     setBackupEnabled("enabled");
     // Simulate backup failure by setting lastError in store after backupNow
@@ -171,7 +171,7 @@ describe("DirtyUnloadBanner", () => {
     await waitFor(() => {
       expect(screen.getByText(/Backup failed/)).toBeInTheDocument();
     });
-    expect(mockClearFlag).not.toHaveBeenCalled();
+    expect(mockClearFlag).toHaveBeenCalled();
   });
 
   it("variant A: shows error when scheduler is not available", async () => {
@@ -194,7 +194,7 @@ describe("DirtyUnloadBanner", () => {
       expect(screen.getByText(/Backup failed/)).toBeInTheDocument();
     });
     expect(mockBackupNow).not.toHaveBeenCalled();
-    expect(mockClearFlag).not.toHaveBeenCalled();
+    expect(mockClearFlag).toHaveBeenCalled();
   });
 
   it("dismiss button clears flag and hides banner", async () => {
@@ -294,6 +294,41 @@ describe("DirtyUnloadBanner", () => {
     expect(screen.getByText("Dismiss")).toBeInTheDocument();
   });
 
+  it("error state links to backup settings", async () => {
+    setFlagPresent();
+    setBackupEnabled("enabled");
+    const onOpenSettings = vi.fn();
+    mockBackupNow.mockImplementationOnce(async () => {
+      useTranscriptStore.setState({
+        backupState: {
+          ...useTranscriptStore.getState().backupState,
+          lastError: "Backup folder not accessible",
+        },
+      });
+    });
+
+    render(<DirtyUnloadBanner onOpenSettings={onOpenSettings} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Create safety backup")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Create safety backup"));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Reconnect or choose a backup folder in settings."),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Open backup settings"));
+
+    expect(onOpenSettings).toHaveBeenCalledWith("backup");
+    expect(mockClearFlag).toHaveBeenCalled();
+  });
+
   it("variant B: re-authorize success triggers backup and shows success", async () => {
     setFlagPresent();
     setBackupEnabled("error");
@@ -341,7 +376,7 @@ describe("DirtyUnloadBanner", () => {
     });
     expect(mockReauthorize).toHaveBeenCalled();
     expect(mockBackupNow).not.toHaveBeenCalled();
-    expect(mockClearFlag).not.toHaveBeenCalled();
+    expect(mockClearFlag).toHaveBeenCalled();
   });
 
   it("variant B: shows error when scheduler is not available", async () => {
@@ -363,7 +398,7 @@ describe("DirtyUnloadBanner", () => {
       expect(screen.getByText(/Backup failed/)).toBeInTheDocument();
     });
     expect(mockReauthorize).not.toHaveBeenCalled();
-    expect(mockClearFlag).not.toHaveBeenCalled();
+    expect(mockClearFlag).toHaveBeenCalled();
   });
 
   it("Bug B: banner does NOT re-appear after dismiss when backupState.status changes", async () => {

--- a/client/src/lib/backup/BackupScheduler.ts
+++ b/client/src/lib/backup/BackupScheduler.ts
@@ -191,7 +191,12 @@ export class BackupScheduler {
     // Before unload: persist dirty flag to localStorage for recovery on next startup
     this.beforeUnloadHandler = () => {
       const state = this.store?.getState();
-      if (state?.backupConfig.enabled && !isPersistenceSuppressed() && this.hasDirty()) {
+      if (
+        state?.backupConfig.enabled &&
+        state.backupState.status === "enabled" &&
+        !isPersistenceSuppressed() &&
+        this.hasDirty()
+      ) {
         setDirtyUnloadFlag();
       }
     };

--- a/client/src/lib/backup/__tests__/BackupScheduler.test.ts
+++ b/client/src/lib/backup/__tests__/BackupScheduler.test.ts
@@ -1046,6 +1046,28 @@ describe("BackupScheduler", () => {
       scheduler.stop();
     });
 
+    it("does not write dirty-unload flag when backup folder is inaccessible", () => {
+      const provider = makeMockProvider();
+      const store = makeStore({ enabled: true, backupIntervalMinutes: 5 });
+      const scheduler = new BackupScheduler(provider);
+      scheduler.start(store);
+
+      store.setState({
+        segments: [{ id: "1" }, { id: "2" }] as unknown[],
+        backupState: {
+          ...store.getState().backupState,
+          status: "error",
+          lastError: "Backup folder not accessible",
+        },
+      });
+      store.notify();
+
+      window.dispatchEvent(new Event("beforeunload"));
+
+      expect(localStorage.getItem("flowscribe:dirty-unload")).toBeNull();
+      scheduler.stop();
+    });
+
     it("does not write dirty-unload flag during persistence suppression", () => {
       mockIsPersistenceSuppressed.mockReturnValue(true);
       const provider = makeMockProvider();

--- a/client/src/translations/de.json
+++ b/client/src/translations/de.json
@@ -360,6 +360,8 @@
       "dismissButton": "Schließen",
       "savingMessage": "Backup wird erstellt…",
       "successMessage": "Sicherheits-Backup gespeichert",
+      "reconnectHint": "Verbinde den Backup-Ordner erneut oder wähle einen Ordner in den Einstellungen.",
+      "openBackupSettingsButton": "Backup-Einstellungen öffnen",
       "errorMessage": "Backup fehlgeschlagen: {{error}}",
       "schedulerNotAvailable": "Backup-Planer nicht verfügbar"
     },

--- a/client/src/translations/en.json
+++ b/client/src/translations/en.json
@@ -413,6 +413,8 @@
       "dismissButton": "Dismiss",
       "savingMessage": "Creating backup…",
       "successMessage": "Safety backup saved",
+      "reconnectHint": "Reconnect or choose a backup folder in settings.",
+      "openBackupSettingsButton": "Open backup settings",
       "errorMessage": "Backup failed: {{error}}",
       "schedulerNotAvailable": "Backup scheduler not available"
     },

--- a/docs/issues/0010-backup-beforeunload-not-checked-on-startup.md
+++ b/docs/issues/0010-backup-beforeunload-not-checked-on-startup.md
@@ -52,7 +52,7 @@ On startup, if the flag is present, a user-facing banner appears at the bottom o
 **State machine:** `hidden → showing → saving → success / error`
 
 - **Success:** clears flag, auto-dismisses after 4 seconds
-- **Error:** shows inline error, keeps dismiss button, does NOT clear flag (so banner reappears on next load)
+- **Error:** shows inline error, clears the flag, keeps dismiss button, and links to the Backup settings tab when settings navigation is available
 - **Dismiss:** clears flag, hides banner immediately
 - **Scheduler not available:** treated as error (prevents false success)
 
@@ -67,14 +67,14 @@ On startup, if the flag is present, a user-facing banner appears at the bottom o
 - `client/src/lib/backup/dirtyUnloadFlag.ts` — flag utility (set/read/clear with 24h expiry)
 - `client/src/lib/backup/__tests__/dirtyUnloadFlag.test.ts` — 7 tests
 - `client/src/components/backup/DirtyUnloadBanner.tsx` — banner component
-- `client/src/components/backup/__tests__/DirtyUnloadBanner.test.tsx` — 14 tests
+- `client/src/components/backup/__tests__/DirtyUnloadBanner.test.tsx` — 15 tests
 
 ### Modified files
-- `client/src/lib/backup/BackupScheduler.ts` — uses `setDirtyUnloadFlag()`, stores handler ref, cleans up in `stop()`, adds `reauthorize()` method
-- `client/src/lib/backup/__tests__/BackupScheduler.test.ts` — 3 new beforeunload tests
+- `client/src/lib/backup/BackupScheduler.ts` — uses `setDirtyUnloadFlag()` only while backup access is healthy, stores handler ref, cleans up in `stop()`, adds `reauthorize()` method
+- `client/src/lib/backup/__tests__/BackupScheduler.test.ts` — 4 new beforeunload tests
 - `client/src/components/transcript-editor/EditorDialogs.tsx` — mounts `DirtyUnloadBanner`
-- `client/src/translations/en.json` — 11 keys under `backup.dirtyUnload.*`
-- `client/src/translations/de.json` — 11 keys under `backup.dirtyUnload.*`
+- `client/src/translations/en.json` — 13 keys under `backup.dirtyUnload.*`
+- `client/src/translations/de.json` — 13 keys under `backup.dirtyUnload.*`
 
 ---
 
@@ -83,4 +83,6 @@ On startup, if the flag is present, a user-facing banner appears at the bottom o
 1. **Interactive banner over silent auto-backup:** Auto-backup cannot request FS permissions (requires user gesture), and users deserve to see what happened. The banner pattern is consistent with `RestoreBanner`.
 2. **localStorage over sessionStorage:** `sessionStorage` is cleared on browser close/crash, defeating the purpose. `localStorage` with a timestamp and 24h TTL avoids stale flags accumulating.
 3. **`scheduler.reauthorize()` over new provider instance:** `FileSystemProvider.getHandle()` caches the directory handle on the instance. Creating a new provider instance and calling `enable()` saves a new handle to IndexedDB but leaves the scheduler's cached handle unchanged — subsequent `backupNow()` calls would use the old revoked handle. `reauthorize()` calls `enable()` on the scheduler's own provider, updating the cached handle in place.
-4. **No coordination with RestoreBanner:** Both banners render independently. The scenario where both appear simultaneously is extremely unlikely (requires dirty unload + restorable snapshot from a different session).
+4. **Error clears the dirty-unload flag:** Once the banner is visible, the user has been notified. Failed safety-backup attempts must not create a startup loop, especially when the configured folder is no longer accessible.
+5. **No dirty-unload flag while backup access is unhealthy:** If the backup folder is already inaccessible, startup recovery should not route the user into the same failed backup path again.
+6. **No coordination with RestoreBanner:** Both banners render independently. The scenario where both appear simultaneously is extremely unlikely (requires dirty unload + restorable snapshot from a different session).

--- a/docs/issues/0010-backup-beforeunload-not-checked-on-startup.md
+++ b/docs/issues/0010-backup-beforeunload-not-checked-on-startup.md
@@ -52,7 +52,7 @@ On startup, if the flag is present, a user-facing banner appears at the bottom o
 **State machine:** `hidden → showing → saving → success / error`
 
 - **Success:** clears flag, auto-dismisses after 4 seconds
-- **Error:** shows inline error, clears the flag, keeps dismiss button, and links to the Backup settings tab when settings navigation is available
+- **Error:** shows inline error, keeps dismiss button, does NOT clear flag (so banner reappears on next load), and links to the Backup settings tab when settings navigation is available
 - **Dismiss:** clears flag, hides banner immediately
 - **Scheduler not available:** treated as error (prevents false success)
 
@@ -83,6 +83,6 @@ On startup, if the flag is present, a user-facing banner appears at the bottom o
 1. **Interactive banner over silent auto-backup:** Auto-backup cannot request FS permissions (requires user gesture), and users deserve to see what happened. The banner pattern is consistent with `RestoreBanner`.
 2. **localStorage over sessionStorage:** `sessionStorage` is cleared on browser close/crash, defeating the purpose. `localStorage` with a timestamp and 24h TTL avoids stale flags accumulating.
 3. **`scheduler.reauthorize()` over new provider instance:** `FileSystemProvider.getHandle()` caches the directory handle on the instance. Creating a new provider instance and calling `enable()` saves a new handle to IndexedDB but leaves the scheduler's cached handle unchanged — subsequent `backupNow()` calls would use the old revoked handle. `reauthorize()` calls `enable()` on the scheduler's own provider, updating the cached handle in place.
-4. **Error clears the dirty-unload flag:** Once the banner is visible, the user has been notified. Failed safety-backup attempts must not create a startup loop, especially when the configured folder is no longer accessible.
+4. **Error keeps the dirty-unload flag:** A failed safety-backup attempt means no backup was created. The flag stays so the user is reminded on the next load.
 5. **No dirty-unload flag while backup access is unhealthy:** If the backup folder is already inaccessible, startup recovery should not route the user into the same failed backup path again.
 6. **No coordination with RestoreBanner:** Both banners render independently. The scenario where both appear simultaneously is extremely unlikely (requires dirty unload + restorable snapshot from a different session).


### PR DESCRIPTION
## Summary
- clear handled dirty-unload backup errors so the startup banner does not loop
- avoid setting the dirty-unload flag when backup access is already unhealthy
- add a backup settings link and localized reconnect hint for backup failures

## Verification
- npm run check
- npm run lint:fix
- npm test