### PR TITLE
fix(backup): stop dirty-unload recovery loop

### DIFF
--- a/client/src/lib/backup/BackupScheduler.ts
+++ b/client/src/lib/backup/BackupScheduler.ts
@@ -543,12 +543,15 @@ export class BackupScheduler {
           this.globalDirty = false;
         }
       }
-      // When includeGlobalState is disabled no global snapshot is written, but
-      // globalDirty must still be cleared so that hasDirty() correctly returns
+      // When includeGlobalState is disabled no global snapshot is ever written,
+      // so globalDirty must be cleared here so that hasDirty() correctly returns
       // false after a successful session backup. Without this, the beforeunload
       // handler would set the dirty-unload flag even though all sessions were
       // backed up cleanly.
-      if (!shouldBackupGlobal && this.globalDirty) {
+      // Exclude the manual-download-backup path: that path skips global backups
+      // intentionally (download provider writes only the active session), so
+      // globalDirty must stay set for the next scheduled backup to pick up.
+      if (!state.backupConfig.includeGlobalState && !isManualDownloadBackup && this.globalDirty) {
         this.lastBackedUpGlobalFingerprint = this.lastSeenGlobalFingerprint;
         this.globalDirty = false;
       }

--- a/client/src/lib/backup/BackupScheduler.ts
+++ b/client/src/lib/backup/BackupScheduler.ts
@@ -543,6 +543,15 @@ export class BackupScheduler {
           this.globalDirty = false;
         }
       }
+      // When includeGlobalState is disabled no global snapshot is written, but
+      // globalDirty must still be cleared so that hasDirty() correctly returns
+      // false after a successful session backup. Without this, the beforeunload
+      // handler would set the dirty-unload flag even though all sessions were
+      // backed up cleanly.
+      if (!shouldBackupGlobal && this.globalDirty) {
+        this.lastBackedUpGlobalFingerprint = this.lastSeenGlobalFingerprint;
+        this.globalDirty = false;
+      }
       this.pendingInitialSnapshot = false;
 
       // Prune and write manifest

--- a/client/src/lib/backup/__tests__/BackupScheduler.test.ts
+++ b/client/src/lib/backup/__tests__/BackupScheduler.test.ts
@@ -1012,6 +1012,37 @@ describe("BackupScheduler", () => {
       scheduler.stop();
     });
 
+    it("does not write dirty-unload flag after successful backup when includeGlobalState is false", async () => {
+      // Regression: when includeGlobalState is false, globalDirty is never reset
+      // inside backupBatch, so hasDirty() remains true and beforeunload sets the flag
+      // even after a completely successful session backup.
+      const provider = makeMockProvider();
+      const store = makeStore({
+        enabled: true,
+        backupIntervalMinutes: 5,
+        includeGlobalState: false,
+      });
+      const scheduler = new BackupScheduler(provider);
+      scheduler.start(store);
+
+      // Trigger a global fingerprint change so globalDirty becomes true
+      store.setState({
+        segments: [{ id: "1" }, { id: "2" }] as unknown[],
+        globalStateFingerprint: "fp-changed",
+      });
+      store.notify();
+
+      // Successful backup
+      await scheduler.backupNow("scheduled");
+
+      // globalDirty is still true because includeGlobalState=false skips the reset
+      // beforeunload must NOT set the flag — sessions were cleanly backed up
+      window.dispatchEvent(new Event("beforeunload"));
+
+      expect(localStorage.getItem("flowscribe:dirty-unload")).toBeNull();
+      scheduler.stop();
+    });
+
     it("does not mark dirty on disabled to enabled transition", () => {
       const provider = makeMockProvider();
       const store = makeStore({ enabled: false, backupIntervalMinutes: 5 });
@@ -1062,6 +1093,26 @@ describe("BackupScheduler", () => {
       });
       store.notify();
 
+      window.dispatchEvent(new Event("beforeunload"));
+
+      expect(localStorage.getItem("flowscribe:dirty-unload")).toBeNull();
+      scheduler.stop();
+    });
+
+    it("does NOT write dirty-unload flag after a successful backup", async () => {
+      const provider = makeMockProvider();
+      const store = makeStore({ enabled: true, backupIntervalMinutes: 5 });
+      const scheduler = new BackupScheduler(provider);
+      scheduler.start(store);
+
+      // Simulate an edit → dirty
+      store.setState({ segments: [{ id: "1" }, { id: "2" }] as unknown[] });
+      store.notify();
+
+      // Backup succeeds
+      await scheduler.backupNow("scheduled");
+
+      // After successful backup the dirty flag must not be set on beforeunload
       window.dispatchEvent(new Event("beforeunload"));
 
       expect(localStorage.getItem("flowscribe:dirty-unload")).toBeNull();

--- a/client/src/lib/backup/__tests__/BackupScheduler.test.ts
+++ b/client/src/lib/backup/__tests__/BackupScheduler.test.ts
@@ -1043,6 +1043,43 @@ describe("BackupScheduler", () => {
       scheduler.stop();
     });
 
+    it("keeps globalDirty set after a manual download backup so the next scheduled backup picks up global changes", async () => {
+      // Regression guard: the manual-download path (isManualDownloadBackup=true) skips
+      // global snapshot writes intentionally. globalDirty must NOT be cleared here,
+      // otherwise subsequent scheduled backups miss global state changes (lexicon, settings).
+      const provider = makeMockProvider();
+      (provider.isSupported as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      // Add triggerDownload/hasPendingDownload so isDownloadProvider() returns true
+      const downloadProvider = {
+        ...provider,
+        triggerDownload: vi.fn(),
+        hasPendingDownload: vi.fn(() => false),
+      };
+      const store = makeStore({
+        enabled: true,
+        backupIntervalMinutes: 5,
+        includeGlobalState: true,
+      });
+      const scheduler = new BackupScheduler(downloadProvider as unknown as typeof provider);
+      scheduler.start(store);
+
+      // Global settings change → globalDirty = true
+      store.setState({ globalStateFingerprint: "fp-settings-changed" });
+      store.notify();
+
+      // Manual download backup — writes only the active session, not global state
+      await scheduler.backupNow("manual");
+
+      // globalDirty must still be true so the next scheduled backup writes the global snapshot
+      // beforeunload should therefore still set the flag
+      store.setState({ segments: [{ id: "1" }, { id: "2" }] as unknown[] });
+      store.notify();
+      window.dispatchEvent(new Event("beforeunload"));
+
+      expect(localStorage.getItem("flowscribe:dirty-unload")).not.toBeNull();
+      scheduler.stop();
+    });
+
     it("does not mark dirty on disabled to enabled transition", () => {
       const provider = makeMockProvider();
       const store = makeStore({ enabled: false, backupIntervalMinutes: 5 });


### PR DESCRIPTION
## Changes

**fix: stop dirty-unload recovery loop** (`fdd2faa`)
- Clear dirty-unload flag only on backup success, dismiss, or settings navigation — not on error
- Avoid setting the flag when backup folder is already inaccessible (`status !== "enabled"`)
- Add reconnect hint + settings link in error state

**fix: revert flag-clear on backup error** (`097e82b`)
- Reverts incorrect behaviour from above where errors cleared the flag
- Tests restored to their correct `not.toHaveBeenCalled()` assertions

**fix: clear globalDirty after successful backup when includeGlobalState is false** (`e7913de`)
- Root cause of the recurring banner: `globalDirty` was never reset when global backups are disabled, so `hasDirty()` always returned `true` and the `beforeunload` flag was set on every page close

## Verification
- `npm run check` ✓
- `npm run lint:fix` ✓
- `npm test` ✓ — 166 test files, 1585 tests