### PR TITLE
fix(backup): stop dirty-unload recovery loop

### DIFF
--- a/client/src/lib/backup/BackupScheduler.ts
+++ b/client/src/lib/backup/BackupScheduler.ts
@@ -305,7 +305,16 @@ export class BackupScheduler {
       this.lastSeenGlobalFingerprint = fp;
       // Only mark dirty if the new fingerprint differs from the last backed-up one.
       if (fp !== this.lastBackedUpGlobalFingerprint) {
-        this.globalDirty = true;
+        // The store initialises globalStateFingerprint to "0" and the persistence
+        // subscriber increments it on the first tick — which may happen after
+        // scheduler.start() because initBackup() is async. The "0" value is a
+        // reserved sentinel that means "not yet computed". Treat any transition
+        // away from "0" as a baseline slide, not a real mutation.
+        if (this.lastBackedUpGlobalFingerprint === "0") {
+          this.lastBackedUpGlobalFingerprint = fp;
+        } else {
+          this.globalDirty = true;
+        }
       }
     }
   }

--- a/client/src/lib/backup/__tests__/BackupScheduler.test.ts
+++ b/client/src/lib/backup/__tests__/BackupScheduler.test.ts
@@ -990,6 +990,27 @@ describe("BackupScheduler", () => {
       mockIsPersistenceSuppressed.mockReturnValue(false);
     });
 
+    it("does not set globalDirty when persistence subscriber increments fingerprint from initial '0' after scheduler start", () => {
+      // Regression: the store initialises globalStateFingerprint to "0". The
+      // persistence subscriber increments it to "1" on the first store tick —
+      // which may happen after scheduler.start() because initBackup() is async.
+      // onStateChange must treat this first increment as a baseline change, not
+      // as a real global-state mutation.
+      const provider = makeMockProvider();
+      const store = makeStore({ backupIntervalMinutes: 5 });
+      store.setState({ globalStateFingerprint: "0" }); // simulate real store initial value
+      const scheduler = new BackupScheduler(provider);
+      scheduler.start(store); // seeds lastSeenGlobalFingerprint = "0"
+
+      // Persistence subscriber fires and bumps fingerprint to "1"
+      store.setState({ globalStateFingerprint: "1" });
+      store.notify();
+
+      window.dispatchEvent(new Event("beforeunload"));
+      expect(localStorage.getItem("flowscribe:dirty-unload")).toBeNull();
+      scheduler.stop();
+    });
+
     it("keeps globalDirty false on first tick after startup", async () => {
       const provider = makeMockProvider();
       const store = makeStore({ backupIntervalMinutes: 5 });


### PR DESCRIPTION
## Summary

Five commits addressing the root causes of the spurious "Unsaved changes detected" banner.

## Commits

**`fdd2faa`** — stop dirty-unload recovery loop
- Avoid setting the flag when backup folder is already inaccessible (`status !== "enabled"`)
- Add reconnect hint + settings link in error state (i18n EN/DE)

**`097e82b`** — revert flag-clear on backup error
- Reverts incorrect change: flag must persist until backup actually succeeds

**`e7913de`** — clear globalDirty after successful backup when `includeGlobalState` is false
- When global backups are disabled, `globalDirty` was never reset, so `hasDirty()` always returned `true`

**`452b425`** — restrict globalDirty reset to `includeGlobalState=false`, exclude manual download path
- Manual download backups intentionally skip global snapshots; `globalDirty` must stay set for the next scheduled backup

**`32feb9b`** — treat initial fingerprint `"0"→"1"` tick as baseline, not dirty
- Root cause of the recurring banner: `globalStateFingerprint` starts at `"0"`, persistence subscriber increments it on first tick — after the async `initBackup()` — causing `onStateChange` to set `globalDirty=true` on every startup

## Verification
- `npm run check` ✓
- `npm run lint:fix` ✓
- Backup test suite: 158 tests passed