### PR TITLE
fix(backup): treat initial fingerprint '0'→'1' tick as baseline, not dirty

### DIFF
--- a/client/src/lib/backup/BackupScheduler.ts
+++ b/client/src/lib/backup/BackupScheduler.ts
@@ -305,7 +305,16 @@ export class BackupScheduler {
       this.lastSeenGlobalFingerprint = fp;
       // Only mark dirty if the new fingerprint differs from the last backed-up one.
       if (fp !== this.lastBackedUpGlobalFingerprint) {
-        this.globalDirty = true;
+        // The store initialises globalStateFingerprint to "0" and the persistence
+        // subscriber increments it on the first tick — which may happen after
+        // scheduler.start() because initBackup() is async. The "0" value is a
+        // reserved sentinel that means "not yet computed". Treat any transition
+        // away from "0" as a baseline slide, not a real mutation.
+        if (this.lastBackedUpGlobalFingerprint === "0") {
+          this.lastBackedUpGlobalFingerprint = fp;
+        } else {
+          this.globalDirty = true;
+        }
       }
     }
   }

--- a/client/src/lib/backup/__tests__/BackupScheduler.test.ts
+++ b/client/src/lib/backup/__tests__/BackupScheduler.test.ts
@@ -990,6 +990,27 @@ describe("BackupScheduler", () => {
       mockIsPersistenceSuppressed.mockReturnValue(false);
     });
 
+    it("does not set globalDirty when persistence subscriber increments fingerprint from initial '0' after scheduler start", () => {
+      // Regression: the store initialises globalStateFingerprint to "0". The
+      // persistence subscriber increments it to "1" on the first store tick —
+      // which may happen after scheduler.start() because initBackup() is async.
+      // onStateChange must treat this first increment as a baseline change, not
+      // as a real global-state mutation.
+      const provider = makeMockProvider();
+      const store = makeStore({ backupIntervalMinutes: 5 });
+      store.setState({ globalStateFingerprint: "0" }); // simulate real store initial value
+      const scheduler = new BackupScheduler(provider);
+      scheduler.start(store); // seeds lastSeenGlobalFingerprint = "0"
+
+      // Persistence subscriber fires and bumps fingerprint to "1"
+      store.setState({ globalStateFingerprint: "1" });
+      store.notify();
+
+      window.dispatchEvent(new Event("beforeunload"));
+      expect(localStorage.getItem("flowscribe:dirty-unload")).toBeNull();
+      scheduler.stop();
+    });
+
     it("keeps globalDirty false on first tick after startup", async () => {
       const provider = makeMockProvider();
       const store = makeStore({ backupIntervalMinutes: 5 });


### PR DESCRIPTION
## Problem

`globalStateFingerprint` starts at `"0"` in the store. The persistence subscriber increments it to `"1"` on the first tick — which happens after the async `initBackup()` call. `onStateChange` treated this `"0"→"1"` change as a real global-state mutation and set `globalDirty=true`, causing `beforeunload` to set the dirty-unload flag on every page close — even after a clean backup or an explicit Dismiss.

## Fix

Treat any fingerprint transition away from the sentinel value `"0"` as a baseline slide rather than a dirty mutation. Subsequent changes (from any non-zero value) are counted normally.

## Verification
- `npm run check` ✓
- `npm run lint:fix` ✓
- Backup test suite: 158 tests passed (51 BackupScheduler)