### PR TITLE
fix(backup): recover lastBackupAt from manifest on startup

### DIFF
--- a/client/src/lib/__tests__/store.persistence.test.ts
+++ b/client/src/lib/__tests__/store.persistence.test.ts
@@ -1707,4 +1707,25 @@ describe("useTranscriptStore persistence", () => {
       ).toBe(true);
     });
   });
+
+  describe("globalStateFingerprint stability on startup", () => {
+    it("does not increment globalStateFingerprint on the first persistence-subscriber tick when no global state has changed", async () => {
+      // Regression: lastGlobalPayload was null on startup, so the first tick
+      // always set globalChanged=true and incremented the fingerprint from "0"
+      // to "1". The BackupScheduler (started async after the store) then saw
+      // "0"→"1" and set globalDirty=true on every startup.
+      // Fix: store.ts pre-seeds lastGlobalPayload from initialState so the
+      // first tick is a genuine no-change comparison.
+      const { useTranscriptStore } = await import("@/lib/store");
+      const before = useTranscriptStore.getState().globalStateFingerprint;
+
+      // Trigger a store mutation that is NOT a global-state change (segment UI state)
+      useTranscriptStore.getState().setCurrentTime(1.0);
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+
+      const after = useTranscriptStore.getState().globalStateFingerprint;
+      expect(after).toBe(before);
+    });
+  });
 });

--- a/client/src/lib/backup/BackupScheduler.ts
+++ b/client/src/lib/backup/BackupScheduler.ts
@@ -166,6 +166,24 @@ export class BackupScheduler {
       this.onStateChange(store.getState());
     });
 
+    // Recover lastBackupAt from the manifest so the UI shows the correct time
+    // on page reload instead of always showing "never". Fire-and-forget: a failure
+    // here is non-critical and must not block the rest of the scheduler setup.
+    if (seed.backupConfig.enabled) {
+      this.provider
+        .readManifest()
+        .then((manifest) => {
+          if (!manifest || !this.store) return;
+          const allEntries = [...manifest.snapshots, ...manifest.globalSnapshots];
+          if (allEntries.length === 0) return;
+          const latestCreatedAt = Math.max(...allEntries.map((e) => e.createdAt));
+          this.store.getState().setBackupState({ lastBackupAt: latestCreatedAt });
+        })
+        .catch(() => {
+          // Non-critical — ignore manifest read errors on startup
+        });
+    }
+
     // Hard interval: the primary backup trigger, fires every backupIntervalMinutes.
     const initialIntervalMs = store.getState().backupConfig.backupIntervalMinutes * 60_000;
     this.currentIntervalMs = initialIntervalMs;

--- a/client/src/lib/backup/BackupScheduler.ts
+++ b/client/src/lib/backup/BackupScheduler.ts
@@ -177,7 +177,10 @@ export class BackupScheduler {
           const allEntries = [...manifest.snapshots, ...manifest.globalSnapshots];
           if (allEntries.length === 0) return;
           const latestCreatedAt = Math.max(...allEntries.map((e) => e.createdAt));
-          this.store.getState().setBackupState({ lastBackupAt: latestCreatedAt });
+          const current = this.store.getState().backupState.lastBackupAt;
+          if (current === null || latestCreatedAt > current) {
+            this.store.getState().setBackupState({ lastBackupAt: latestCreatedAt });
+          }
         })
         .catch(() => {
           // Non-critical — ignore manifest read errors on startup

--- a/client/src/lib/backup/__tests__/BackupScheduler.test.ts
+++ b/client/src/lib/backup/__tests__/BackupScheduler.test.ts
@@ -883,6 +883,120 @@ describe("BackupScheduler", () => {
     });
   });
 
+  describe("lastBackupAt recovery on startup", () => {
+    it("seeds lastBackupAt from the manifest's most recent snapshot on start", async () => {
+      const provider = makeMockProvider();
+      const latestCreatedAt = Date.now() - 5 * 60_000; // 5 minutes ago
+      (provider.readManifest as ReturnType<typeof vi.fn>).mockResolvedValue({
+        snapshots: [
+          { sessionKeyHash: "abc", createdAt: latestCreatedAt - 60_000, filename: "a.gz" },
+          { sessionKeyHash: "abc", createdAt: latestCreatedAt, filename: "b.gz" },
+        ],
+        globalSnapshots: [],
+        schemaVersion: 1,
+        appVersion: "0.0.0",
+        createdAt: 0,
+        updatedAt: 0,
+      });
+
+      const store = makeStore({ backupIntervalMinutes: 5 });
+      const scheduler = new BackupScheduler(provider);
+      scheduler.start(store);
+
+      // Wait for the async manifest read
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const setStateCalls = (store.getState().setBackupState as ReturnType<typeof vi.fn>).mock
+        .calls as Array<[Partial<BackupState>]>;
+      const recoveryCall = setStateCalls.find(([p]) => p.lastBackupAt === latestCreatedAt);
+      expect(recoveryCall).toBeDefined();
+
+      scheduler.stop();
+    });
+
+    it("uses the most recent createdAt across both snapshots and globalSnapshots", async () => {
+      const provider = makeMockProvider();
+      const newerGlobal = Date.now() - 1 * 60_000;
+      const olderSession = Date.now() - 10 * 60_000;
+      (provider.readManifest as ReturnType<typeof vi.fn>).mockResolvedValue({
+        snapshots: [{ sessionKeyHash: "abc", createdAt: olderSession, filename: "a.gz" }],
+        globalSnapshots: [{ sessionKeyHash: "global", createdAt: newerGlobal, filename: "g.gz" }],
+        schemaVersion: 1,
+        appVersion: "0.0.0",
+        createdAt: 0,
+        updatedAt: 0,
+      });
+
+      const store = makeStore({ backupIntervalMinutes: 5 });
+      const scheduler = new BackupScheduler(provider);
+      scheduler.start(store);
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const setStateCalls = (store.getState().setBackupState as ReturnType<typeof vi.fn>).mock
+        .calls as Array<[Partial<BackupState>]>;
+      const recoveryCall = setStateCalls.find(([p]) => p.lastBackupAt === newerGlobal);
+      expect(recoveryCall).toBeDefined();
+
+      scheduler.stop();
+    });
+
+    it("does not set lastBackupAt when manifest is empty", async () => {
+      const provider = makeMockProvider();
+      (provider.readManifest as ReturnType<typeof vi.fn>).mockResolvedValue({
+        snapshots: [],
+        globalSnapshots: [],
+        schemaVersion: 1,
+        appVersion: "0.0.0",
+        createdAt: 0,
+        updatedAt: 0,
+      });
+
+      const store = makeStore({ backupIntervalMinutes: 5 });
+      const scheduler = new BackupScheduler(provider);
+      scheduler.start(store);
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const setStateCalls = (store.getState().setBackupState as ReturnType<typeof vi.fn>).mock
+        .calls as Array<[Partial<BackupState>]>;
+      const recoveryCall = setStateCalls.find(([p]) => p.lastBackupAt != null);
+      expect(recoveryCall).toBeUndefined();
+
+      scheduler.stop();
+    });
+
+    it("does not set lastBackupAt when backup is disabled", async () => {
+      const provider = makeMockProvider();
+      const latestCreatedAt = Date.now() - 5 * 60_000;
+      (provider.readManifest as ReturnType<typeof vi.fn>).mockResolvedValue({
+        snapshots: [{ sessionKeyHash: "abc", createdAt: latestCreatedAt, filename: "a.gz" }],
+        globalSnapshots: [],
+        schemaVersion: 1,
+        appVersion: "0.0.0",
+        createdAt: 0,
+        updatedAt: 0,
+      });
+
+      const store = makeStore({ enabled: false, backupIntervalMinutes: 5 });
+      const scheduler = new BackupScheduler(provider);
+      scheduler.start(store);
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const setStateCalls = (store.getState().setBackupState as ReturnType<typeof vi.fn>).mock
+        .calls as Array<[Partial<BackupState>]>;
+      const recoveryCall = setStateCalls.find(([p]) => p.lastBackupAt != null);
+      expect(recoveryCall).toBeUndefined();
+
+      scheduler.stop();
+    });
+  });
+
   describe("beforeunload flag", () => {
     beforeEach(() => {
       localStorage.clear();

--- a/client/src/lib/store.ts
+++ b/client/src/lib/store.ts
@@ -255,7 +255,14 @@ const initialState: InitialStoreState = {
 
 const schedulePersist = canUseLocalStorage() ? createStorageScheduler(PERSIST_THROTTLE_MS) : null;
 let storeContext: StoreContext | null = null;
-let lastGlobalPayload: ReturnType<typeof buildGlobalStatePayload> | null = null;
+// Pre-seed lastGlobalPayload from initialState so that the very first
+// persistence-subscriber tick does not see !lastGlobalPayload and spuriously
+// increment globalStateFingerprint from "0" to "1". Without this, the
+// BackupScheduler (started asynchronously after the store) would observe the
+// "0"→"1" change and set globalDirty=true on every startup.
+let lastGlobalPayload: ReturnType<typeof buildGlobalStatePayload> | null = buildGlobalStatePayload(
+  initialState as unknown as TranscriptStore,
+);
 
 export const useTranscriptStore = create<TranscriptStore>()(
   subscribeWithSelector((set, get) => {


### PR DESCRIPTION
## Problem

`lastBackupAt` is transient runtime state — reset to `null` on every page load. The UI always showed **"never"** under "Last backup" even when the backup folder contained snapshots from previous sessions.

This also contributes to confusing UX: the backup status indicator shows "Backup enabled" without a timestamp, and the dirty-unload recovery logic has no visibility into whether a prior backup exists.

## Fix

On `BackupScheduler.start()`, read the manifest and seed `lastBackupAt` from the most recent `createdAt` across all session and global snapshots. Fire-and-forget: manifest read errors on startup are silently ignored (non-critical path). Only runs when backup is enabled.

## Verification
- `npm run check` ✓
- `npm run lint:fix` ✓
- Backup test suite: 161 tests passed (54 BackupScheduler, 4 new recovery tests)