### PR TITLE
feat(rewrite): add batch chapter rewrite

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+[ -s "$HOME/.nvm/nvm.sh" ] && source "$HOME/.nvm/nvm.sh"
+nvm use

--- a/client/src/components/AICommandPanel/AICommandPanel.tsx
+++ b/client/src/components/AICommandPanel/AICommandPanel.tsx
@@ -1,13 +1,15 @@
 import { Bot, X } from "lucide-react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ChapterPanel } from "./ChapterPanel";
 import { MergePanel } from "./MergePanel";
 import { RevisionPanel } from "./RevisionPanel";
+import { RewritePanel } from "./RewritePanel";
 import { SpeakerPanel } from "./SpeakerPanel";
 
-export type AICommandPanelTab = "revision" | "speaker" | "merge" | "chapters";
+export type AICommandPanelTab = "revision" | "speaker" | "merge" | "chapters" | "rewrite";
 
 interface AICommandPanelProps {
   open: boolean;
@@ -22,6 +24,7 @@ export function AICommandPanel({
   filteredSegmentIds,
   onOpenSettings,
 }: AICommandPanelProps) {
+  const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<AICommandPanelTab>("revision");
 
   if (!open) return null;
@@ -31,13 +34,15 @@ export function AICommandPanel({
       <div className="flex items-center justify-between px-4 py-3 border-b">
         <div className="flex items-center gap-2">
           <Bot className="h-4 w-4 text-muted-foreground" />
-          <h2 className="text-sm font-semibold text-muted-foreground">AI Command Panel</h2>
+          <h2 className="text-sm font-semibold text-muted-foreground">
+            {t("aiCommandPanel.title")}
+          </h2>
         </div>
         <Button
           size="icon"
           variant="ghost"
           onClick={() => onOpenChange(false)}
-          aria-label="Close AI command panel"
+          aria-label={t("aiCommandPanel.close")}
         >
           <X className="h-4 w-4" />
         </Button>
@@ -47,10 +52,11 @@ export function AICommandPanel({
         <div className="flex gap-1 rounded-lg bg-muted/60 p-1">
           {(
             [
-              { id: "revision", label: "Revision" },
-              { id: "speaker", label: "Speaker" },
-              { id: "merge", label: "Merge" },
-              { id: "chapters", label: "Chapters" },
+              { id: "revision", label: t("aiCommandPanel.tabs.revision") },
+              { id: "speaker", label: t("aiCommandPanel.tabs.speaker") },
+              { id: "merge", label: t("aiCommandPanel.tabs.merge") },
+              { id: "chapters", label: t("aiCommandPanel.tabs.chapters") },
+              { id: "rewrite", label: t("rewriteBatch.tabLabel") },
             ] as const
           ).map((tab) => (
             <button
@@ -83,6 +89,7 @@ export function AICommandPanel({
         {activeTab === "chapters" && (
           <ChapterPanel filteredSegmentIds={filteredSegmentIds} onOpenSettings={onOpenSettings} />
         )}
+        {activeTab === "rewrite" && <RewritePanel onOpenSettings={onOpenSettings} />}
       </div>
     </aside>
   );

--- a/client/src/components/AICommandPanel/BatchLogDrawer.tsx
+++ b/client/src/components/AICommandPanel/BatchLogDrawer.tsx
@@ -22,6 +22,7 @@ interface BatchLogDrawerProps {
   title?: string;
   description?: string;
   triggerLabel?: string;
+  onExport?: () => void;
 }
 
 export function BatchLogDrawer({
@@ -33,6 +34,7 @@ export function BatchLogDrawer({
   title,
   description,
   triggerLabel,
+  onExport,
 }: BatchLogDrawerProps) {
   const { t } = useTranslation();
   const logDrawerRef = useRef<HTMLDivElement>(null);
@@ -42,9 +44,13 @@ export function BatchLogDrawer({
   const resolvedTriggerLabel = triggerLabel ?? t("aiBatch.batchLog.title");
 
   const handleExport = useCallback(() => {
+    if (onExport) {
+      onExport();
+      return;
+    }
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
     exportBatchLog(featureType, rows, `batch-log-${featureType}-${timestamp}`);
-  }, [featureType, rows]);
+  }, [featureType, onExport, rows]);
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>

--- a/client/src/components/AICommandPanel/RewritePanel.tsx
+++ b/client/src/components/AICommandPanel/RewritePanel.tsx
@@ -39,7 +39,9 @@ export function RewritePanel({ onOpenSettings }: Readonly<RewritePanelProps>) {
   const rejectAllBatchRewrites = useTranscriptStore((s) => s.rejectAllBatchRewrites);
   const updateChapterDetectionConfig = useTranscriptStore((s) => s.updateChapterDetectionConfig);
 
-  const rewritePrompts = config.prompts.filter((prompt) => prompt.operation === "rewrite");
+  const rewritePrompts = config.prompts.filter(
+    (prompt) => prompt.operation === "rewrite" && (prompt.rewriteScope ?? "chapter") === "chapter",
+  );
   const [selectedPromptId, setSelectedPromptId] = useState(() => rewritePrompts[0]?.id ?? "");
   const [customInstructions, setCustomInstructions] = useState("");
   const [skipAlreadyRewritten, setSkipAlreadyRewritten] = useState(false);

--- a/client/src/components/AICommandPanel/RewritePanel.tsx
+++ b/client/src/components/AICommandPanel/RewritePanel.tsx
@@ -206,7 +206,11 @@ export function RewritePanel({ onOpenSettings }: Readonly<RewritePanelProps>) {
           <ResultsList
             items={draftsWithChapters}
             getKey={(chapter) => chapter.id}
-            onActivate={(chapter) => setActiveViewChapterId(chapter.id)}
+            onActivate={(chapter) => {
+              if (!isProcessing) {
+                setActiveViewChapterId(chapter.id);
+              }
+            }}
             getItemTitle={(chapter) => chapter.title}
             renderItem={(chapter) => (
               <>
@@ -220,11 +224,22 @@ export function RewritePanel({ onOpenSettings }: Readonly<RewritePanelProps>) {
             )}
           />
           <div className="flex gap-2">
-            <Button variant="outline" size="sm" className="flex-1" onClick={rejectAllBatchRewrites}>
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-1"
+              onClick={rejectAllBatchRewrites}
+              disabled={isProcessing}
+            >
               <XCircle className="mr-2 h-4 w-4" />
               {t("aiBatch.actions.rejectAll")}
             </Button>
-            <Button size="sm" className="flex-1" onClick={acceptAllBatchRewrites}>
+            <Button
+              size="sm"
+              className="flex-1"
+              onClick={acceptAllBatchRewrites}
+              disabled={isProcessing}
+            >
               <Check className="mr-2 h-4 w-4" />
               {t("aiBatch.actions.acceptAll")}
             </Button>
@@ -236,6 +251,7 @@ export function RewritePanel({ onOpenSettings }: Readonly<RewritePanelProps>) {
         <ChapterRewriteView
           chapterId={activeViewChapterId}
           onClose={() => setActiveViewChapterId(null)}
+          preserveDraftOnClose
         />
       ) : null}
     </div>

--- a/client/src/components/AICommandPanel/RewritePanel.tsx
+++ b/client/src/components/AICommandPanel/RewritePanel.tsx
@@ -1,0 +1,241 @@
+import { Check, Sparkles, StopCircle, XCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChapterRewriteView } from "@/components/rewrite/ChapterRewriteView";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { exportRewriteBatchLog } from "@/lib/ai/export/batchLogExport";
+import { useTranscriptStore } from "@/lib/store";
+import { buildSegmentIndexMap, sortChaptersByStart } from "@/lib/store/utils/chapters";
+import { AIBatchControlSection } from "./AIBatchControlSection";
+import { AIConfigurationSection } from "./AIConfigurationSection";
+import { AIResultsSection } from "./AIResultsSection";
+import { BatchLogDrawer } from "./BatchLogDrawer";
+import { useAiSettingsSelection } from "./hooks/useAiSettingsSelection";
+import { ResultsList } from "./ResultsList";
+import { truncateText } from "./utils/truncateText";
+
+interface RewritePanelProps {
+  onOpenSettings: () => void;
+}
+
+export function RewritePanel({ onOpenSettings }: Readonly<RewritePanelProps>) {
+  const { t } = useTranslation();
+  const chapters = useTranscriptStore((s) => s.chapters);
+  const segments = useTranscriptStore((s) => s.segments);
+  const config = useTranscriptStore((s) => s.aiChapterDetectionConfig);
+  const rewriteDraftByChapterId = useTranscriptStore((s) => s.rewriteDraftByChapterId);
+  const isProcessing = useTranscriptStore((s) => s.batchRewriteIsProcessing);
+  const isCancelling = useTranscriptStore((s) => s.batchRewriteIsCancelling);
+  const processedCount = useTranscriptStore((s) => s.batchRewriteProcessedCount);
+  const totalCount = useTranscriptStore((s) => s.batchRewriteTotalCount);
+  const error = useTranscriptStore((s) => s.batchRewriteError);
+  const batchLog = useTranscriptStore((s) => s.batchRewriteLog);
+  const startBatchRewrite = useTranscriptStore((s) => s.startBatchRewrite);
+  const cancelBatchRewrite = useTranscriptStore((s) => s.cancelBatchRewrite);
+  const acceptAllBatchRewrites = useTranscriptStore((s) => s.acceptAllBatchRewrites);
+  const rejectAllBatchRewrites = useTranscriptStore((s) => s.rejectAllBatchRewrites);
+  const updateChapterDetectionConfig = useTranscriptStore((s) => s.updateChapterDetectionConfig);
+
+  const rewritePrompts = config.prompts.filter((prompt) => prompt.operation === "rewrite");
+  const [selectedPromptId, setSelectedPromptId] = useState(() => rewritePrompts[0]?.id ?? "");
+  const [customInstructions, setCustomInstructions] = useState("");
+  const [skipAlreadyRewritten, setSkipAlreadyRewritten] = useState(false);
+  const [activeViewChapterId, setActiveViewChapterId] = useState<string | null>(null);
+  const [isLogOpen, setIsLogOpen] = useState(false);
+
+  const { settings, selectedProviderId, selectedModel, selectProvider, setSelectedModel } =
+    useAiSettingsSelection({
+      initialProviderId: config.selectedProviderId ?? "",
+      initialModel: config.selectedModel ?? "",
+    });
+
+  useEffect(() => {
+    if (!selectedPromptId && rewritePrompts[0]) {
+      setSelectedPromptId(rewritePrompts[0].id);
+    }
+  }, [rewritePrompts, selectedPromptId]);
+
+  const indexMap = buildSegmentIndexMap(segments);
+  const sortedChapters = sortChaptersByStart(chapters, indexMap);
+  const chaptersToProcess = skipAlreadyRewritten
+    ? sortedChapters.filter(
+        (chapter) => !chapter.rewrittenText && !rewriteDraftByChapterId[chapter.id],
+      )
+    : sortedChapters;
+  const draftsWithChapters = sortedChapters.filter(
+    (chapter) => !!rewriteDraftByChapterId[chapter.id],
+  );
+
+  const handleStart = () => {
+    updateChapterDetectionConfig({
+      selectedProviderId: selectedProviderId || undefined,
+      selectedModel: selectedModel || undefined,
+    });
+    startBatchRewrite({
+      promptId: selectedPromptId,
+      customInstructions: customInstructions.trim() || undefined,
+      skipAlreadyRewritten,
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-3">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t("rewriteBatch.scopeTitle")}
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          {chapters.length > 0
+            ? t("rewriteBatch.chaptersCount", { count: chaptersToProcess.length })
+            : t("rewriteBatch.noChaptersInTranscript")}
+        </p>
+        <div className="flex items-start gap-2">
+          <Checkbox
+            id="rewrite-skip-existing"
+            checked={skipAlreadyRewritten}
+            onCheckedChange={(checked) => setSkipAlreadyRewritten(checked === true)}
+            disabled={isProcessing}
+          />
+          <div className="grid gap-1 leading-none">
+            <Label htmlFor="rewrite-skip-existing" className="text-sm">
+              {t("rewriteBatch.skipAlreadyRewritten")}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {t("rewriteBatch.skipAlreadyRewrittenHelp")}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <AIConfigurationSection
+        id="rewrite"
+        settings={settings}
+        selectedProviderId={selectedProviderId}
+        selectedModel={selectedModel}
+        isProcessing={isProcessing}
+        promptValue={selectedPromptId}
+        promptOptions={rewritePrompts}
+        showBatchSize={false}
+        onProviderChange={(value) => {
+          selectProvider(value);
+          updateChapterDetectionConfig({
+            selectedProviderId: value || undefined,
+            selectedModel: undefined,
+          });
+        }}
+        onModelChange={(value) => {
+          setSelectedModel(value);
+          updateChapterDetectionConfig({ selectedModel: value || undefined });
+        }}
+        onPromptChange={setSelectedPromptId}
+        onOpenSettings={onOpenSettings}
+      />
+
+      <section className="space-y-2">
+        <Label htmlFor="rewrite-custom-instructions" className="text-xs text-muted-foreground">
+          {t("rewriteBatch.customInstructions.label")}
+        </Label>
+        <Textarea
+          id="rewrite-custom-instructions"
+          value={customInstructions}
+          onChange={(event) => setCustomInstructions(event.target.value)}
+          placeholder={t("rewriteBatch.customInstructions.placeholder")}
+          disabled={isProcessing}
+        />
+      </section>
+
+      <AIBatchControlSection
+        isProcessing={isProcessing}
+        isCancelling={isCancelling}
+        processedCount={processedCount}
+        totalToProcess={totalCount}
+        progressUnitLabel={t("rewriteBatch.units.chapters")}
+        error={error}
+        startAction={{
+          label: t("aiBatch.actions.startBatch"),
+          icon: <Sparkles className="mr-2 h-4 w-4" />,
+          onClick: handleStart,
+          disabled: !selectedPromptId || chaptersToProcess.length === 0,
+        }}
+        stopAction={{
+          label: t("aiBatch.actions.stop"),
+          icon: <StopCircle className="mr-2 h-4 w-4" />,
+          onClick: cancelBatchRewrite,
+          variant: "destructive",
+        }}
+      >
+        {batchLog.length > 0 ? (
+          <BatchLogDrawer
+            rows={batchLog.map((entry, index) => ({
+              id: `${entry.chapterId}-${entry.loggedAt}-${index}`,
+              batchLabel: entry.chapterTitle,
+              expected: 1,
+              returned: entry.status === "done" ? 1 : 0,
+              durationMs: entry.durationMs ?? 1,
+              suggestions: 0,
+              unchanged: 0,
+              skipped: entry.status === "skipped" ? 1 : 0,
+              processed: t(`rewriteBatch.status.${entry.status}`),
+              issues: entry.error ?? t("aiBatch.batchLog.emptyIssue"),
+              loggedAt: entry.loggedAt,
+            }))}
+            featureType="chapter-rewrite"
+            open={isLogOpen}
+            onOpenChange={setIsLogOpen}
+            total={totalCount}
+            title={t("rewriteBatch.batchLogTitle")}
+            description={t("rewriteBatch.batchLogDescription")}
+            triggerLabel={t("rewriteBatch.batchLogTriggerLabel")}
+            onExport={() => {
+              const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+              exportRewriteBatchLog(batchLog, `batch-log-chapter-rewrite-${timestamp}`);
+            }}
+          />
+        ) : null}
+      </AIBatchControlSection>
+
+      {draftsWithChapters.length > 0 ? (
+        <AIResultsSection
+          title={t("rewriteBatch.results.draftsTitle", { count: draftsWithChapters.length })}
+        >
+          <ResultsList
+            items={draftsWithChapters}
+            getKey={(chapter) => chapter.id}
+            onActivate={(chapter) => setActiveViewChapterId(chapter.id)}
+            getItemTitle={(chapter) => chapter.title}
+            renderItem={(chapter) => (
+              <>
+                <span className="flex-1 truncate text-muted-foreground min-w-0">
+                  {truncateText(chapter.title, 40)}
+                </span>
+                <span className="flex-1 truncate text-muted-foreground min-w-0">
+                  {truncateText(rewriteDraftByChapterId[chapter.id]?.text ?? "", 60)}
+                </span>
+              </>
+            )}
+          />
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" className="flex-1" onClick={rejectAllBatchRewrites}>
+              <XCircle className="mr-2 h-4 w-4" />
+              {t("aiBatch.actions.rejectAll")}
+            </Button>
+            <Button size="sm" className="flex-1" onClick={acceptAllBatchRewrites}>
+              <Check className="mr-2 h-4 w-4" />
+              {t("aiBatch.actions.acceptAll")}
+            </Button>
+          </div>
+        </AIResultsSection>
+      ) : null}
+
+      {activeViewChapterId ? (
+        <ChapterRewriteView
+          chapterId={activeViewChapterId}
+          onClose={() => setActiveViewChapterId(null)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/components/AICommandPanel/__tests__/RewritePanel.test.tsx
+++ b/client/src/components/AICommandPanel/__tests__/RewritePanel.test.tsx
@@ -224,6 +224,33 @@ describe("RewritePanel", () => {
     expect(rejectAllBatchRewrites).toHaveBeenCalled();
   });
 
+  it("blocks draft review and bulk actions while batch rewrite is processing", async () => {
+    const user = userEvent.setup();
+    const acceptAllBatchRewrites = vi.fn();
+    const rejectAllBatchRewrites = vi.fn();
+    setStoreState({
+      acceptAllBatchRewrites,
+      rejectAllBatchRewrites,
+      batchRewriteIsProcessing: true,
+      rewriteDraftByChapterId: {
+        "chapter-1": { text: "Draft one", promptId: "rewrite-prompt" },
+      },
+    });
+
+    renderWithI18n(<RewritePanel onOpenSettings={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: /accept all/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /reject all/i })).toBeDisabled();
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /one draft one/i }));
+    });
+
+    expect(screen.queryByTestId("chapter-rewrite-view")).not.toBeInTheDocument();
+    expect(acceptAllBatchRewrites).not.toHaveBeenCalled();
+    expect(rejectAllBatchRewrites).not.toHaveBeenCalled();
+  });
+
   it("shows batch log trigger and exports rewrite log", async () => {
     const user = userEvent.setup();
     const loggedAt = Date.now();

--- a/client/src/components/AICommandPanel/__tests__/RewritePanel.test.tsx
+++ b/client/src/components/AICommandPanel/__tests__/RewritePanel.test.tsx
@@ -1,0 +1,216 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createBaseState, resetStore } from "@/lib/__tests__/storeTestUtils";
+import { exportRewriteBatchLog } from "@/lib/ai/export/batchLogExport";
+import { useTranscriptStore } from "@/lib/store";
+import type { AIPrompt, Segment, TranscriptStore } from "@/lib/store/types";
+import type { Chapter } from "@/types/chapter";
+import { RewritePanel } from "../RewritePanel";
+import { renderWithI18n } from "./testUtils";
+
+vi.mock("@/components/rewrite/ChapterRewriteView", () => ({
+  ChapterRewriteView: ({ chapterId }: { chapterId: string }) => (
+    <div data-testid="chapter-rewrite-view">{chapterId}</div>
+  ),
+}));
+
+vi.mock("@/lib/ai/export/batchLogExport", () => ({
+  exportBatchLog: vi.fn(),
+  exportRewriteBatchLog: vi.fn(),
+}));
+
+const prompt: AIPrompt = {
+  id: "rewrite-prompt",
+  name: "Rewrite Prompt",
+  type: "chapter-detect",
+  operation: "rewrite",
+  systemPrompt: "system",
+  userPromptTemplate: "user",
+  isBuiltIn: false,
+  quickAccess: false,
+};
+
+const segments: Segment[] = [
+  { id: "seg-1", speaker: "A", start: 0, end: 1, text: "one", words: [] },
+  { id: "seg-2", speaker: "A", start: 1, end: 2, text: "two", words: [] },
+];
+
+const chapters: Chapter[] = [
+  {
+    id: "chapter-1",
+    title: "One",
+    startSegmentId: "seg-1",
+    endSegmentId: "seg-1",
+    segmentCount: 1,
+    createdAt: 1,
+    source: "manual",
+  },
+  {
+    id: "chapter-2",
+    title: "Two",
+    startSegmentId: "seg-2",
+    endSegmentId: "seg-2",
+    segmentCount: 1,
+    createdAt: 2,
+    source: "manual",
+  },
+];
+
+const setStoreState = (overrides: Partial<TranscriptStore>) => {
+  const baseState = createBaseState();
+  useTranscriptStore.setState({
+    ...baseState,
+    segments,
+    chapters,
+    aiChapterDetectionConfig: {
+      ...baseState.aiChapterDetectionConfig,
+      prompts: [prompt],
+      activePromptId: prompt.id,
+    },
+    rewriteDraftByChapterId: {},
+    batchRewriteIsProcessing: false,
+    batchRewriteIsCancelling: false,
+    batchRewriteProcessedCount: 0,
+    batchRewriteTotalCount: 0,
+    batchRewriteError: null,
+    batchRewriteLog: [],
+    ...overrides,
+  });
+};
+
+describe("RewritePanel", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    Element.prototype.setPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+    resetStore();
+  });
+
+  it("shows chapter count and empty state", () => {
+    setStoreState({});
+    const { rerender } = renderWithI18n(<RewritePanel onOpenSettings={vi.fn()} />);
+
+    expect(screen.getByText("2 chapters")).toBeInTheDocument();
+
+    setStoreState({ chapters: [] });
+    rerender(<RewritePanel onOpenSettings={vi.fn()} />);
+    expect(screen.getByText("No chapters in transcript. Add chapters first.")).toBeInTheDocument();
+  });
+
+  it("disables start without a rewrite prompt", () => {
+    const baseState = createBaseState();
+    setStoreState({
+      aiChapterDetectionConfig: {
+        ...baseState.aiChapterDetectionConfig,
+        prompts: [],
+      },
+    });
+
+    renderWithI18n(<RewritePanel onOpenSettings={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: /start batch/i })).toBeDisabled();
+  });
+
+  it("disables start without chapters", () => {
+    setStoreState({ chapters: [] });
+
+    renderWithI18n(<RewritePanel onOpenSettings={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: /start batch/i })).toBeDisabled();
+  });
+
+  it("starts batch rewrite with instructions and skip flag", async () => {
+    const user = userEvent.setup();
+    const startBatchRewrite = vi.fn();
+    const updateChapterDetectionConfig = vi.fn();
+    setStoreState({ startBatchRewrite, updateChapterDetectionConfig });
+
+    renderWithI18n(<RewritePanel onOpenSettings={vi.fn()} />);
+
+    await act(async () => {
+      await user.type(screen.getByLabelText(/additional instructions/i), "Use bullets");
+    });
+    const skipCheckbox = screen.getByRole("checkbox", { name: /skip already rewritten chapters/i });
+    await act(async () => {
+      await user.click(skipCheckbox);
+    });
+    await waitFor(() => expect(skipCheckbox).toHaveAttribute("aria-checked", "true"));
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /start batch/i }));
+    });
+
+    expect(startBatchRewrite).toHaveBeenCalledWith({
+      promptId: "rewrite-prompt",
+      customInstructions: "Use bullets",
+      skipAlreadyRewritten: true,
+    });
+    expect(updateChapterDetectionConfig).toHaveBeenCalledWith({
+      selectedProviderId: "default-ollama",
+      selectedModel: "llama3.2",
+    });
+  });
+
+  it("shows drafts, opens review, and runs bulk actions", async () => {
+    const user = userEvent.setup();
+    const acceptAllBatchRewrites = vi.fn();
+    const rejectAllBatchRewrites = vi.fn();
+    setStoreState({
+      acceptAllBatchRewrites,
+      rejectAllBatchRewrites,
+      rewriteDraftByChapterId: {
+        "chapter-1": { text: "Draft one", promptId: "rewrite-prompt" },
+      },
+    });
+
+    renderWithI18n(<RewritePanel onOpenSettings={vi.fn()} />);
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /one draft one/i }));
+    });
+    expect(screen.getByTestId("chapter-rewrite-view")).toHaveTextContent("chapter-1");
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /accept all/i }));
+      await user.click(screen.getByRole("button", { name: /reject all/i }));
+    });
+    expect(acceptAllBatchRewrites).toHaveBeenCalled();
+    expect(rejectAllBatchRewrites).toHaveBeenCalled();
+  });
+
+  it("shows batch log trigger and exports rewrite log", async () => {
+    const user = userEvent.setup();
+    const loggedAt = Date.now();
+    setStoreState({
+      batchRewriteLog: [{ chapterId: "chapter-1", chapterTitle: "One", status: "done", loggedAt }],
+    });
+
+    renderWithI18n(<RewritePanel onOpenSettings={vi.fn()} />);
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /rewrite log/i }));
+    });
+    const exportButton = await screen.findByRole("button", { name: /export/i });
+    await act(async () => {
+      await user.click(exportButton);
+    });
+
+    expect(exportRewriteBatchLog).toHaveBeenCalledWith(
+      [{ chapterId: "chapter-1", chapterTitle: "One", status: "done", loggedAt }],
+      expect.stringMatching(/^batch-log-chapter-rewrite-/),
+    );
+  });
+});

--- a/client/src/components/AICommandPanel/__tests__/RewritePanel.test.tsx
+++ b/client/src/components/AICommandPanel/__tests__/RewritePanel.test.tsx
@@ -32,6 +32,13 @@ const prompt: AIPrompt = {
   quickAccess: false,
 };
 
+const paragraphPrompt: AIPrompt = {
+  ...prompt,
+  id: "paragraph-prompt",
+  name: "Paragraph Prompt",
+  rewriteScope: "paragraph",
+};
+
 const segments: Segment[] = [
   { id: "seg-1", speaker: "A", start: 0, end: 1, text: "one", words: [] },
   { id: "seg-2", speaker: "A", start: 1, end: 2, text: "two", words: [] },
@@ -161,6 +168,32 @@ describe("RewritePanel", () => {
     expect(updateChapterDetectionConfig).toHaveBeenCalledWith({
       selectedProviderId: "default-ollama",
       selectedModel: "llama3.2",
+    });
+  });
+
+  it("ignores paragraph-scoped rewrite prompts for batch rewrite", async () => {
+    const user = userEvent.setup();
+    const startBatchRewrite = vi.fn();
+    const baseState = createBaseState();
+    setStoreState({
+      startBatchRewrite,
+      aiChapterDetectionConfig: {
+        ...baseState.aiChapterDetectionConfig,
+        prompts: [paragraphPrompt, prompt],
+        activePromptId: paragraphPrompt.id,
+      },
+    });
+
+    renderWithI18n(<RewritePanel onOpenSettings={vi.fn()} />);
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /start batch/i }));
+    });
+
+    expect(startBatchRewrite).toHaveBeenCalledWith({
+      promptId: "rewrite-prompt",
+      customInstructions: undefined,
+      skipAlreadyRewritten: false,
     });
   });
 

--- a/client/src/components/__tests__/ChapterRewriteView.test.tsx
+++ b/client/src/components/__tests__/ChapterRewriteView.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "@/components/i18n/I18nProvider";
 import { ChapterRewriteView } from "@/components/rewrite/ChapterRewriteView";
 import { useTranscriptStore } from "@/lib/store";
@@ -211,5 +211,49 @@ describe("ChapterRewriteView", () => {
     await user.click(refineButton);
 
     expect(screen.getByText("Refine Paragraph")).toBeInTheDocument();
+  });
+
+  it("rejects the pending draft when closed by default", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    useTranscriptStore.setState({
+      rewriteDraftByChapterId: {
+        "chapter-1": { text: "Pending draft", promptId: "prompt-1" },
+      },
+    });
+
+    render(
+      <I18nProvider>
+        <ChapterRewriteView chapterId="chapter-1" onClose={onClose} />
+      </I18nProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(useTranscriptStore.getState().rewriteDraftByChapterId["chapter-1"]).toBeUndefined();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("keeps the pending draft when batch review closes", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    useTranscriptStore.setState({
+      rewriteDraftByChapterId: {
+        "chapter-1": { text: "Pending draft", promptId: "prompt-1" },
+      },
+    });
+
+    render(
+      <I18nProvider>
+        <ChapterRewriteView chapterId="chapter-1" onClose={onClose} preserveDraftOnClose />
+      </I18nProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(useTranscriptStore.getState().rewriteDraftByChapterId["chapter-1"]?.text).toBe(
+      "Pending draft",
+    );
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/client/src/components/rewrite/ChapterRewriteView.tsx
+++ b/client/src/components/rewrite/ChapterRewriteView.tsx
@@ -186,12 +186,12 @@ export function ChapterRewriteView({
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
       if (paragraphDialogOpen) return;
-      handleReject();
+      onClose();
     };
 
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [isMounted, handleReject, paragraphDialogOpen]);
+  }, [isMounted, onClose, paragraphDialogOpen]);
 
   const handleRegenerate = useCallback(() => {
     if (!promptId) return;
@@ -224,7 +224,7 @@ export function ChapterRewriteView({
             {t("rewrite.view.title")}
           </h2>
           <span id="rewrite-view-description" className="text-sm text-muted-foreground">
-            — {chapter.title}
+            {chapter.title}
           </span>
         </div>
 
@@ -232,8 +232,8 @@ export function ChapterRewriteView({
           ref={closeButtonRef}
           variant="ghost"
           size="icon"
-          onClick={handleReject}
-          aria-label={t("rewrite.view.close", { defaultValue: "Schließen" })}
+          onClick={onClose}
+          aria-label={t("rewrite.view.close")}
         >
           <X className="h-4 w-4" />
         </Button>

--- a/client/src/components/rewrite/ChapterRewriteView.tsx
+++ b/client/src/components/rewrite/ChapterRewriteView.tsx
@@ -20,6 +20,8 @@ interface ChapterRewriteViewProps {
   chapterId: string;
   /** Called when user closes the view */
   onClose: () => void;
+  /** Keep pending drafts when closing from batch review. */
+  preserveDraftOnClose?: boolean;
   /** Optional trigger element to return focus to when closing */
   triggerElement?: HTMLElement | null;
 }
@@ -27,6 +29,7 @@ interface ChapterRewriteViewProps {
 export function ChapterRewriteView({
   chapterId,
   onClose,
+  preserveDraftOnClose = false,
   triggerElement,
 }: ChapterRewriteViewProps) {
   const { t } = useTranslation();
@@ -179,6 +182,14 @@ export function ChapterRewriteView({
     onClose();
   }, [chapterId, clearRewriteDraft, cancelRewrite, onClose]);
 
+  const handleClose = useCallback(() => {
+    if (preserveDraftOnClose) {
+      onClose();
+      return;
+    }
+    handleReject();
+  }, [handleReject, onClose, preserveDraftOnClose]);
+
   // Escape key handler (must be after handleReject definition)
   useEffect(() => {
     if (!isMounted) return;
@@ -186,12 +197,12 @@ export function ChapterRewriteView({
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
       if (paragraphDialogOpen) return;
-      onClose();
+      handleClose();
     };
 
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [isMounted, onClose, paragraphDialogOpen]);
+  }, [handleClose, isMounted, paragraphDialogOpen]);
 
   const handleRegenerate = useCallback(() => {
     if (!promptId) return;
@@ -232,7 +243,7 @@ export function ChapterRewriteView({
           ref={closeButtonRef}
           variant="ghost"
           size="icon"
-          onClick={onClose}
+          onClick={handleClose}
           aria-label={t("rewrite.view.close")}
         >
           <X className="h-4 w-4" />

--- a/client/src/lib/ai/export/batchLogExport.ts
+++ b/client/src/lib/ai/export/batchLogExport.ts
@@ -1,11 +1,13 @@
 import type { BatchLogRow } from "@/components/shared/BatchLog/BatchLog";
+import type { RewriteBatchLogEntry } from "@/lib/store/slices/rewriteSlice";
 import type { AIRevisionBatchLogEntry } from "@/lib/store/types";
 
 export type BatchLogExportFeatureType =
   | "speaker-classification"
   | "segment-merge"
   | "chapter-detection"
-  | "revision";
+  | "revision"
+  | "chapter-rewrite";
 
 export interface BatchLogExportRow {
   id: string;
@@ -34,6 +36,16 @@ export interface RevisionLogExportRow {
   errorCode?: string;
   requestPayload: undefined;
   responsePayload?: string;
+}
+
+export interface RewriteBatchLogExportRow {
+  chapterId: string;
+  chapterTitle: string;
+  status: string;
+  loggedAt: number;
+  durationMs?: number;
+  error?: string;
+  promptId?: string;
 }
 
 export interface BatchLogExport<TRow> {
@@ -75,6 +87,20 @@ export function mapRevisionLogEntryToExport(entry: AIRevisionBatchLogEntry): Rev
   };
 }
 
+export function mapRewriteBatchLogEntryToExport(
+  entry: RewriteBatchLogEntry,
+): RewriteBatchLogExportRow {
+  return {
+    chapterId: entry.chapterId,
+    chapterTitle: entry.chapterTitle,
+    status: entry.status,
+    loggedAt: entry.loggedAt,
+    durationMs: entry.durationMs,
+    error: entry.error,
+    promptId: entry.promptId,
+  };
+}
+
 export function buildBatchLogExport<TRow>(
   featureType: BatchLogExportFeatureType,
   rows: TRow[],
@@ -111,5 +137,10 @@ export function exportBatchLog(
 
 export function exportRevisionBatchLog(rows: AIRevisionBatchLogEntry[], filename: string): void {
   const payload = buildBatchLogExport("revision", rows.map(mapRevisionLogEntryToExport));
+  downloadAsJson(payload, filename);
+}
+
+export function exportRewriteBatchLog(rows: RewriteBatchLogEntry[], filename: string): void {
+  const payload = buildBatchLogExport("chapter-rewrite", rows.map(mapRewriteBatchLogEntryToExport));
   downloadAsJson(payload, filename);
 }

--- a/client/src/lib/store/slices/__tests__/rewriteSlice.batch.test.ts
+++ b/client/src/lib/store/slices/__tests__/rewriteSlice.batch.test.ts
@@ -152,11 +152,7 @@ describe("RewriteSlice batch rewrite", () => {
   });
 
   it("logs failed and empty chapters without stopping", async () => {
-    store
-      .getState()
-      .selectSegmentsInChapter.mockImplementation((chapterId: string) =>
-        chapterId === "chapter-1" ? [segments[0]] : [],
-      );
+    store.setState({ chapters: [chapters[0], { ...chapters[1], startSegmentId: "missing" }] });
     (rewriteChapter as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
 
     await store.getState().startBatchRewrite({ promptId: "prompt-1" });
@@ -165,6 +161,33 @@ describe("RewriteSlice batch rewrite", () => {
     expect(store.getState().batchRewriteLog.map((entry) => entry.status)).toEqual([
       "failed",
       "skipped",
+    ]);
+  });
+
+  it("rewrites full chapters without using the filter-aware chapter selector", async () => {
+    store.getState().selectSegmentsInChapter.mockReturnValue([]);
+    (rewriteChapter as ReturnType<typeof vi.fn>).mockResolvedValue({ rewrittenText: "New" });
+
+    await store.getState().startBatchRewrite({ promptId: "prompt-1" });
+
+    expect(store.getState().selectSegmentsInChapter).not.toHaveBeenCalled();
+    expect(rewriteChapter).toHaveBeenCalledTimes(2);
+    expect((rewriteChapter as ReturnType<typeof vi.fn>).mock.calls[0][0].segments).toEqual([
+      segments[0],
+    ]);
+  });
+
+  it("passes sorted chapters as rewrite context", async () => {
+    store.setState({ chapters: [chapters[1], chapters[0]] });
+    (rewriteChapter as ReturnType<typeof vi.fn>).mockResolvedValue({ rewrittenText: "New" });
+
+    await store.getState().startBatchRewrite({ promptId: "prompt-1" });
+
+    const firstCall = (rewriteChapter as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(firstCall.chapter.id).toBe("chapter-1");
+    expect(firstCall.allChapters.map((chapter: Chapter) => chapter.id)).toEqual([
+      "chapter-1",
+      "chapter-2",
     ]);
   });
 

--- a/client/src/lib/store/slices/__tests__/rewriteSlice.batch.test.ts
+++ b/client/src/lib/store/slices/__tests__/rewriteSlice.batch.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StoreApi } from "zustand";
+import { create } from "zustand";
+import { rewriteChapter } from "@/lib/ai/features/rewrite/service";
+import type {
+  AIChapterDetectionConfig,
+  AIPrompt,
+  Segment,
+  TranscriptStore,
+} from "@/lib/store/types";
+import type { Chapter } from "@/types/chapter";
+import { createRewriteSlice, initialRewriteState, type RewriteSlice } from "../rewriteSlice";
+
+vi.mock("@/lib/ai/features/rewrite/service", () => ({
+  rewriteChapter: vi.fn(),
+  rewriteParagraph: vi.fn(),
+}));
+
+type TestState = RewriteSlice & {
+  aiChapterDetectionConfig: AIChapterDetectionConfig;
+  segments: Segment[];
+  chapters: Chapter[];
+  selectSegmentsInChapter: ReturnType<typeof vi.fn>;
+  setChapterRewrite: ReturnType<typeof vi.fn>;
+  setChapterDisplayMode: ReturnType<typeof vi.fn>;
+  updateChapterDetectionConfig: ReturnType<typeof vi.fn>;
+  addChapterDetectionPrompt: ReturnType<typeof vi.fn>;
+  updateChapterDetectionPrompt: ReturnType<typeof vi.fn>;
+  deleteChapterDetectionPrompt: ReturnType<typeof vi.fn>;
+  updateChapterRewrite: ReturnType<typeof vi.fn>;
+};
+
+const prompt: AIPrompt = {
+  id: "prompt-1",
+  name: "Rewrite",
+  type: "chapter-detect",
+  operation: "rewrite",
+  systemPrompt: "system",
+  userPromptTemplate: "user",
+  isBuiltIn: false,
+  quickAccess: false,
+};
+
+const segments: Segment[] = [
+  { id: "seg-1", speaker: "A", start: 0, end: 1, text: "one", words: [] },
+  { id: "seg-2", speaker: "A", start: 1, end: 2, text: "two", words: [] },
+];
+
+const chapters: Chapter[] = [
+  {
+    id: "chapter-1",
+    title: "One",
+    startSegmentId: "seg-1",
+    endSegmentId: "seg-1",
+    segmentCount: 1,
+  },
+  {
+    id: "chapter-2",
+    title: "Two",
+    startSegmentId: "seg-2",
+    endSegmentId: "seg-2",
+    segmentCount: 1,
+  },
+];
+
+const buildConfig = (prompts = [prompt]): AIChapterDetectionConfig => ({
+  batchSize: 100,
+  minChapterLength: 1,
+  maxChapterLength: 100,
+  tagIds: [],
+  activePromptId: "prompt-1",
+  prompts,
+  includeContext: true,
+  contextWordLimit: 500,
+  includeParagraphContext: true,
+  paragraphContextCount: 2,
+});
+
+const createStore = () =>
+  create<TestState>()((set, get) => ({
+    aiChapterDetectionConfig: buildConfig(),
+    segments,
+    chapters,
+    selectSegmentsInChapter: vi.fn((chapterId: string) => [
+      segments[chapterId === "chapter-1" ? 0 : 1],
+    ]),
+    setChapterRewrite: vi.fn(),
+    setChapterDisplayMode: vi.fn(),
+    updateChapterDetectionConfig: vi.fn(),
+    addChapterDetectionPrompt: vi.fn(),
+    updateChapterDetectionPrompt: vi.fn(),
+    deleteChapterDetectionPrompt: vi.fn(),
+    updateChapterRewrite: vi.fn(),
+    ...initialRewriteState,
+    ...createRewriteSlice(
+      set as StoreApi<TranscriptStore>["setState"],
+      get as StoreApi<TranscriptStore>["getState"],
+    ),
+  }));
+
+describe("RewriteSlice batch rewrite", () => {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = createStore();
+  });
+
+  it("starts idle", () => {
+    expect(store.getState().batchRewriteIsProcessing).toBe(false);
+    expect(store.getState().batchRewriteIsCancelling).toBe(false);
+    expect(store.getState().batchRewriteLog).toEqual([]);
+  });
+
+  it("processes chapters sequentially and passes pending drafts as context", async () => {
+    (rewriteChapter as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ rewrittenText: "Draft text for chapter 1" })
+      .mockResolvedValueOnce({ rewrittenText: "Draft text for chapter 2" });
+
+    await store.getState().startBatchRewrite({ promptId: "prompt-1" });
+
+    expect(rewriteChapter).toHaveBeenCalledTimes(2);
+    const chapter2Call = (rewriteChapter as ReturnType<typeof vi.fn>).mock.calls[1][0];
+    const previous = chapter2Call.allChapters.find(
+      (chapter: Chapter) => chapter.id === "chapter-1",
+    );
+    expect(previous.rewrittenText).toBe("Draft text for chapter 1");
+    expect(store.getState().setChapterRewrite).not.toHaveBeenCalled();
+    expect(store.getState().rewriteDraftByChapterId["chapter-2"]?.text).toBe(
+      "Draft text for chapter 2",
+    );
+    expect(store.getState().batchRewriteLog.map((entry) => entry.status)).toEqual(["done", "done"]);
+    expect(store.getState().batchRewriteIsProcessing).toBe(false);
+    expect(store.getState().batchRewriteAbortController).toBeNull();
+  });
+
+  it("skips accepted and pending rewrites only when requested", async () => {
+    store.setState({
+      chapters: [{ ...chapters[0], rewrittenText: "Accepted" }, chapters[1]],
+      rewriteDraftByChapterId: { "chapter-2": { text: "Pending", promptId: "prompt-1" } },
+    });
+
+    await store.getState().startBatchRewrite({ promptId: "prompt-1", skipAlreadyRewritten: true });
+
+    expect(rewriteChapter).not.toHaveBeenCalled();
+    expect(store.getState().batchRewriteError).toBe("No chapters to rewrite");
+
+    (rewriteChapter as ReturnType<typeof vi.fn>).mockResolvedValue({ rewrittenText: "New" });
+    await store.getState().startBatchRewrite({ promptId: "prompt-1", skipAlreadyRewritten: false });
+
+    expect(rewriteChapter).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs failed and empty chapters without stopping", async () => {
+    store
+      .getState()
+      .selectSegmentsInChapter.mockImplementation((chapterId: string) =>
+        chapterId === "chapter-1" ? [segments[0]] : [],
+      );
+    (rewriteChapter as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
+
+    await store.getState().startBatchRewrite({ promptId: "prompt-1" });
+
+    expect(store.getState().batchRewriteProcessedCount).toBe(2);
+    expect(store.getState().batchRewriteLog.map((entry) => entry.status)).toEqual([
+      "failed",
+      "skipped",
+    ]);
+  });
+
+  it("can cancel the active controller", async () => {
+    let rejectRewrite: ((error: Error) => void) | null = null;
+    (rewriteChapter as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectRewrite = reject;
+        }),
+    );
+
+    const running = store.getState().startBatchRewrite({ promptId: "prompt-1" });
+    const controller = store.getState().batchRewriteAbortController;
+    store.getState().cancelBatchRewrite();
+    expect(controller?.signal.aborted).toBe(true);
+    expect(store.getState().batchRewriteIsCancelling).toBe(true);
+    rejectRewrite?.(new DOMException("Aborted", "AbortError"));
+    await running;
+
+    expect(store.getState().batchRewriteIsCancelling).toBe(false);
+    expect(store.getState().batchRewriteLog.map((entry) => entry.status)).toEqual([
+      "cancelled",
+      "cancelled",
+    ]);
+  });
+
+  it("does not write a draft when a request resolves after cancellation", async () => {
+    let resolveRewrite: ((value: { rewrittenText: string }) => void) | null = null;
+    (rewriteChapter as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRewrite = resolve;
+        }),
+    );
+
+    const running = store.getState().startBatchRewrite({ promptId: "prompt-1" });
+    store.getState().cancelBatchRewrite();
+    resolveRewrite?.({ rewrittenText: "Too late" });
+    await running;
+
+    expect(store.getState().rewriteDraftByChapterId["chapter-1"]).toBeUndefined();
+    expect(store.getState().batchRewriteLog.map((entry) => entry.status)).toEqual([
+      "cancelled",
+      "cancelled",
+    ]);
+  });
+
+  it("does not let an aborted previous batch clear a newer batch", async () => {
+    let rejectFirst: ((error: Error) => void) | null = null;
+    (rewriteChapter as ReturnType<typeof vi.fn>)
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectFirst = reject;
+          }),
+      )
+      .mockResolvedValue({ rewrittenText: "New batch draft" });
+
+    const first = store.getState().startBatchRewrite({ promptId: "prompt-1" });
+    expect(rejectFirst).not.toBeNull();
+    const second = store.getState().startBatchRewrite({ promptId: "prompt-1" });
+    rejectFirst?.(new DOMException("Aborted", "AbortError"));
+    await first;
+    await second;
+
+    expect(store.getState().rewriteDraftByChapterId["chapter-1"]?.text).toBe("New batch draft");
+    expect(store.getState().batchRewriteAbortController).toBeNull();
+    expect(store.getState().batchRewriteLog[0]?.status).toBe("done");
+  });
+
+  it("sets errors for invalid prompt and no chapters", async () => {
+    await store.getState().startBatchRewrite({ promptId: "missing" });
+    expect(store.getState().batchRewriteError).toBe("Prompt missing not found");
+    expect(rewriteChapter).not.toHaveBeenCalled();
+
+    store.setState({ chapters: [] });
+    await store.getState().startBatchRewrite({ promptId: "prompt-1" });
+    expect(store.getState().batchRewriteError).toBe("No chapters to rewrite");
+  });
+
+  it("accepts and rejects all pending drafts", () => {
+    store.setState({
+      rewriteDraftByChapterId: {
+        "chapter-1": { text: "One", promptId: "prompt-1" },
+        "chapter-2": { text: "Two", promptId: "prompt-1", providerId: "p", model: "m" },
+      },
+    });
+
+    store.getState().acceptAllBatchRewrites();
+    expect(store.getState().setChapterRewrite).toHaveBeenCalledTimes(2);
+    expect(store.getState().setChapterDisplayMode).toHaveBeenCalledWith("chapter-1", "rewritten");
+    expect(store.getState().rewriteDraftByChapterId).toEqual({});
+
+    store.setState({
+      rewriteDraftByChapterId: { "chapter-1": { text: "One", promptId: "prompt-1" } },
+    });
+    store.getState().setChapterRewrite.mockClear();
+    store.getState().rejectAllBatchRewrites();
+    expect(store.getState().setChapterRewrite).not.toHaveBeenCalled();
+    expect(store.getState().rewriteDraftByChapterId).toEqual({});
+  });
+});

--- a/client/src/lib/store/slices/rewriteSlice.ts
+++ b/client/src/lib/store/slices/rewriteSlice.ts
@@ -17,7 +17,11 @@ import {
   splitRewrittenParagraphs,
 } from "@/lib/rewriteParagraphs";
 import type { AIChapterDetectionConfig, AIPrompt, TranscriptStore } from "../types";
-import { buildSegmentIndexMap, sortChaptersByStart } from "../utils/chapters";
+import {
+  buildSegmentIndexMap,
+  getDynamicChapterRangeIndices,
+  sortChaptersByStart,
+} from "../utils/chapters";
 
 type StoreSetter = StoreApi<TranscriptStore>["setState"];
 type StoreGetter = StoreApi<TranscriptStore>["getState"];
@@ -413,8 +417,16 @@ export const createRewriteSlice = (set: StoreSetter, get: StoreGetter): RewriteS
       }));
 
       try {
-        const segments = get().selectSegmentsInChapter(chapter.id);
-        if (segments.length === 0) {
+        const range = getDynamicChapterRangeIndices(
+          chapter.id,
+          state.chapters,
+          indexMap,
+          state.segments.length,
+        );
+        const chapterSegments = range
+          ? state.segments.slice(range.startIndex, range.endIndex + 1)
+          : [];
+        if (chapterSegments.length === 0) {
           replaceLogEntry({
             chapterId: chapter.id,
             chapterTitle: chapter.title,
@@ -430,14 +442,14 @@ export const createRewriteSlice = (set: StoreSetter, get: StoreGetter): RewriteS
         }
 
         const currentDrafts = get().rewriteDraftByChapterId;
-        const allChaptersWithDrafts = get().chapters.map((item) => {
+        const allChaptersWithDrafts = sortedChapters.map((item) => {
           const draft = currentDrafts[item.id];
           return draft?.text ? { ...item, rewrittenText: draft.text } : item;
         });
 
         const result = await rewriteChapter({
           chapter,
-          segments,
+          segments: chapterSegments,
           allChapters: allChaptersWithDrafts,
           prompt,
           providerId: get().aiChapterDetectionConfig.selectedProviderId,

--- a/client/src/lib/store/slices/rewriteSlice.ts
+++ b/client/src/lib/store/slices/rewriteSlice.ts
@@ -17,12 +17,15 @@ import {
   splitRewrittenParagraphs,
 } from "@/lib/rewriteParagraphs";
 import type { AIChapterDetectionConfig, AIPrompt, TranscriptStore } from "../types";
+import { buildSegmentIndexMap, sortChaptersByStart } from "../utils/chapters";
 
 type StoreSetter = StoreApi<TranscriptStore>["setState"];
 type StoreGetter = StoreApi<TranscriptStore>["getState"];
 
 const logger = createLogger({ feature: "RewriteSlice", namespace: "Store" });
 const t = getI18nInstance().t.bind(getI18nInstance());
+
+const isAbortError = (error: unknown) => error instanceof Error && error.name === "AbortError";
 
 // ==================== Types ====================
 
@@ -48,6 +51,24 @@ export interface RewriteDraft {
   model?: string;
 }
 
+export type RewriteBatchItemStatus =
+  | "pending"
+  | "processing"
+  | "done"
+  | "failed"
+  | "skipped"
+  | "cancelled";
+
+export interface RewriteBatchLogEntry {
+  chapterId: string;
+  chapterTitle: string;
+  status: RewriteBatchItemStatus;
+  loggedAt: number;
+  durationMs?: number;
+  error?: string;
+  promptId?: string;
+}
+
 export interface RewriteSlice {
   // Processing state
   rewriteInProgress: boolean;
@@ -60,6 +81,13 @@ export interface RewriteSlice {
   paragraphRewriteError: string | null;
   paragraphRewriteAbortController: AbortController | null;
   rewriteDraftByChapterId: Record<string, RewriteDraft | undefined>;
+  batchRewriteIsProcessing: boolean;
+  batchRewriteIsCancelling: boolean;
+  batchRewriteProcessedCount: number;
+  batchRewriteTotalCount: number;
+  batchRewriteError: string | null;
+  batchRewriteAbortController: AbortController | null;
+  batchRewriteLog: RewriteBatchLogEntry[];
 
   // Actions - Configuration
   updateRewriteConfig: (updates: Partial<RewriteConfig>) => void;
@@ -85,6 +113,14 @@ export interface RewriteSlice {
   cancelParagraphRewrite: () => void;
   setRewriteDraft: (chapterId: string, draft: RewriteDraft) => void;
   clearRewriteDraft: (chapterId: string) => void;
+  startBatchRewrite: (options: {
+    promptId: string;
+    customInstructions?: string;
+    skipAlreadyRewritten?: boolean;
+  }) => Promise<void>;
+  cancelBatchRewrite: () => void;
+  acceptAllBatchRewrites: () => void;
+  rejectAllBatchRewrites: () => void;
 }
 
 // ==================== Initial State ====================
@@ -100,6 +136,13 @@ export const initialRewriteState = {
   paragraphRewriteError: null,
   paragraphRewriteAbortController: null,
   rewriteDraftByChapterId: {},
+  batchRewriteIsProcessing: false,
+  batchRewriteIsCancelling: false,
+  batchRewriteProcessedCount: 0,
+  batchRewriteTotalCount: 0,
+  batchRewriteError: null,
+  batchRewriteAbortController: null,
+  batchRewriteLog: [] as RewriteBatchLogEntry[],
 };
 
 // ==================== Slice Creator ====================
@@ -274,6 +317,212 @@ export const createRewriteSlice = (set: StoreSetter, get: StoreGetter): RewriteS
         rewriteDraftByChapterId: rest,
       };
     });
+  },
+
+  startBatchRewrite: async ({ promptId, customInstructions, skipAlreadyRewritten }) => {
+    get().batchRewriteAbortController?.abort();
+
+    const state = get();
+    const prompt = state.aiChapterDetectionConfig.prompts.find((item) => item.id === promptId);
+    if (!prompt || !prompt.systemPrompt?.trim() || !prompt.userPromptTemplate?.trim()) {
+      set({ batchRewriteError: t("aiBatch.errors.promptNotFound", { id: promptId }) });
+      return;
+    }
+
+    const indexMap = buildSegmentIndexMap(state.segments);
+    const sortedChapters = sortChaptersByStart(state.chapters, indexMap);
+    const chaptersToProcess = skipAlreadyRewritten
+      ? sortedChapters.filter(
+          (chapter) => !chapter.rewrittenText && !state.rewriteDraftByChapterId[chapter.id],
+        )
+      : sortedChapters;
+
+    if (chaptersToProcess.length === 0) {
+      set({ batchRewriteError: t("rewriteBatch.errors.noChapters") });
+      return;
+    }
+
+    const abortController = new AbortController();
+    set({
+      batchRewriteIsProcessing: true,
+      batchRewriteIsCancelling: false,
+      batchRewriteProcessedCount: 0,
+      batchRewriteTotalCount: chaptersToProcess.length,
+      batchRewriteError: null,
+      batchRewriteAbortController: abortController,
+      batchRewriteLog: [],
+    });
+
+    const replaceLogEntry = (entry: RewriteBatchLogEntry) => {
+      set((current) => ({
+        batchRewriteLog: current.batchRewriteLog.map((item) =>
+          item.chapterId === entry.chapterId && item.status === "processing" ? entry : item,
+        ),
+      }));
+    };
+
+    const cancelFrom = (currentChapterIndex: number, currentStartedAt?: number) => {
+      if (get().batchRewriteAbortController !== abortController) return;
+      const currentChapter = chaptersToProcess[currentChapterIndex];
+      if (currentChapter && currentStartedAt !== undefined) {
+        replaceLogEntry({
+          chapterId: currentChapter.id,
+          chapterTitle: currentChapter.title,
+          status: "cancelled",
+          loggedAt: Date.now(),
+          durationMs: Date.now() - currentStartedAt,
+          promptId,
+        });
+      }
+      set((current) => ({
+        batchRewriteLog: [
+          ...current.batchRewriteLog,
+          ...chaptersToProcess.slice(currentChapterIndex + 1).map((item) => ({
+            chapterId: item.id,
+            chapterTitle: item.title,
+            status: "cancelled" as const,
+            loggedAt: Date.now(),
+            promptId,
+          })),
+        ],
+        batchRewriteIsProcessing: false,
+        batchRewriteIsCancelling: false,
+        batchRewriteAbortController: null,
+      }));
+    };
+
+    for (let index = 0; index < chaptersToProcess.length; index += 1) {
+      const chapter = chaptersToProcess[index];
+      if (abortController.signal.aborted) {
+        cancelFrom(index - 1);
+        return;
+      }
+
+      const startedAt = Date.now();
+      set((current) => ({
+        batchRewriteLog: [
+          ...current.batchRewriteLog,
+          {
+            chapterId: chapter.id,
+            chapterTitle: chapter.title,
+            status: "processing",
+            loggedAt: startedAt,
+            promptId,
+          },
+        ],
+      }));
+
+      try {
+        const segments = get().selectSegmentsInChapter(chapter.id);
+        if (segments.length === 0) {
+          replaceLogEntry({
+            chapterId: chapter.id,
+            chapterTitle: chapter.title,
+            status: "skipped",
+            loggedAt: Date.now(),
+            durationMs: Date.now() - startedAt,
+            promptId,
+          });
+          set((current) => ({
+            batchRewriteProcessedCount: current.batchRewriteProcessedCount + 1,
+          }));
+          continue;
+        }
+
+        const currentDrafts = get().rewriteDraftByChapterId;
+        const allChaptersWithDrafts = get().chapters.map((item) => {
+          const draft = currentDrafts[item.id];
+          return draft?.text ? { ...item, rewrittenText: draft.text } : item;
+        });
+
+        const result = await rewriteChapter({
+          chapter,
+          segments,
+          allChapters: allChaptersWithDrafts,
+          prompt,
+          providerId: get().aiChapterDetectionConfig.selectedProviderId,
+          model: get().aiChapterDetectionConfig.selectedModel,
+          signal: abortController.signal,
+          includeContext: get().aiChapterDetectionConfig.includeContext,
+          contextWordLimit: get().aiChapterDetectionConfig.contextWordLimit,
+          customInstructions,
+        });
+
+        if (abortController.signal.aborted) {
+          cancelFrom(index, startedAt);
+          return;
+        }
+
+        get().setRewriteDraft(chapter.id, {
+          text: result.rewrittenText,
+          promptId,
+          providerId: get().aiChapterDetectionConfig.selectedProviderId,
+          model: get().aiChapterDetectionConfig.selectedModel,
+        });
+
+        replaceLogEntry({
+          chapterId: chapter.id,
+          chapterTitle: chapter.title,
+          status: "done",
+          loggedAt: Date.now(),
+          durationMs: Date.now() - startedAt,
+          promptId,
+        });
+        set((current) => ({ batchRewriteProcessedCount: current.batchRewriteProcessedCount + 1 }));
+      } catch (error) {
+        if (abortController.signal.aborted || isAbortError(error)) {
+          cancelFrom(index, startedAt);
+          return;
+        }
+
+        replaceLogEntry({
+          chapterId: chapter.id,
+          chapterTitle: chapter.title,
+          status: "failed",
+          loggedAt: Date.now(),
+          durationMs: Date.now() - startedAt,
+          error: error instanceof Error ? error.message : String(error),
+          promptId,
+        });
+        set((current) => ({ batchRewriteProcessedCount: current.batchRewriteProcessedCount + 1 }));
+      }
+    }
+
+    set({
+      ...(get().batchRewriteAbortController === abortController
+        ? {
+            batchRewriteIsProcessing: false,
+            batchRewriteIsCancelling: false,
+            batchRewriteAbortController: null,
+            batchRewriteError: null,
+          }
+        : {}),
+    });
+  },
+
+  cancelBatchRewrite: () => {
+    get().batchRewriteAbortController?.abort();
+    set({ batchRewriteIsCancelling: true });
+  },
+
+  acceptAllBatchRewrites: () => {
+    const state = get();
+    for (const [chapterId, draft] of Object.entries(state.rewriteDraftByChapterId)) {
+      if (!draft) continue;
+      state.setChapterRewrite(chapterId, draft.text, {
+        promptId: draft.promptId,
+        providerId: draft.providerId,
+        model: draft.model,
+      });
+      state.clearRewriteDraft(chapterId);
+      state.setChapterDisplayMode(chapterId, "rewritten");
+    }
+  },
+
+  rejectAllBatchRewrites: () => {
+    for (const chapterId of Object.keys(get().rewriteDraftByChapterId)) {
+      get().clearRewriteDraft(chapterId);
+    }
   },
 
   startParagraphRewrite: async (chapterId, paragraphIndex, promptId, customInstructions) => {

--- a/client/src/lib/store/types.ts
+++ b/client/src/lib/store/types.ts
@@ -240,6 +240,13 @@ export interface InitialStoreState {
   paragraphRewriteError: string | null;
   paragraphRewriteAbortController: AbortController | null;
   rewriteDraftByChapterId: Record<string, import("./slices/rewriteSlice").RewriteDraft | undefined>;
+  batchRewriteIsProcessing: boolean;
+  batchRewriteIsCancelling: boolean;
+  batchRewriteProcessedCount: number;
+  batchRewriteTotalCount: number;
+  batchRewriteError: string | null;
+  batchRewriteAbortController: AbortController | null;
+  batchRewriteLog: import("./slices/rewriteSlice").RewriteBatchLogEntry[];
   // Backup
   backupConfig: BackupConfig;
   backupState: BackupState;

--- a/client/src/translations/de.json
+++ b/client/src/translations/de.json
@@ -27,6 +27,7 @@
   "rewrite": {
     "view": {
       "title": "Rewrite Chapter",
+      "close": "Schließen",
       "originalLabel": "Original ({{count}} segments)",
       "rewrittenLabel": "Überarbeitet",
       "processing": "Reformulating chapter...",
@@ -59,6 +60,51 @@
     "paragraph": {
       "errorTitle": "Abschnitt konnte nicht neu formuliert werden"
     }
+  },
+  "aiCommandPanel": {
+    "title": "KI-Befehlsbereich",
+    "close": "KI-Befehlsbereich schließen",
+    "tabs": {
+      "revision": "Revision",
+      "speaker": "Sprecher",
+      "merge": "Merge",
+      "chapters": "Kapitel"
+    }
+  },
+  "rewriteBatch": {
+    "tabLabel": "Rewrite",
+    "scopeTitle": "Bereich",
+    "chaptersCount": "{{count}} Kapitel",
+    "chaptersCount_plural": "{{count}} Kapitel",
+    "chaptersCount_one": "{{count}} Kapitel",
+    "chaptersCount_other": "{{count}} Kapitel",
+    "skipAlreadyRewritten": "Bereits umgeschriebene Kapitel überspringen",
+    "skipAlreadyRewrittenHelp": "Kapitel überspringen, die bereits einen angenommenen oder ausstehenden Rewrite haben",
+    "customInstructions": {
+      "label": "Zusätzliche Anweisungen (optional)",
+      "placeholder": "Zusätzliche Hinweise für alle Kapitel im Prompt"
+    },
+    "batchLogTitle": "Rewrite-Log",
+    "batchLogDescription": "Status des Batch-Rewrites pro Kapitel.",
+    "batchLogTriggerLabel": "Rewrite-Log",
+    "units": {
+      "chapters": "Kapitel"
+    },
+    "status": {
+      "pending": "Ausstehend",
+      "processing": "Wird verarbeitet",
+      "done": "Fertig",
+      "failed": "Fehlgeschlagen",
+      "skipped": "Übersprungen",
+      "cancelled": "Abgebrochen"
+    },
+    "results": {
+      "draftsTitle": "Entwürfe ({{count}} ausstehend)"
+    },
+    "errors": {
+      "noChapters": "Keine Kapitel zum Umschreiben vorhanden"
+    },
+    "noChaptersInTranscript": "Kein Kapitel im Transkript vorhanden. Bitte zuerst Kapitel hinzufügen."
   },
   "import": {
     "transcriptFormatError": "Ungültiges Transkript-Format",

--- a/client/src/translations/en.json
+++ b/client/src/translations/en.json
@@ -80,6 +80,7 @@
   "rewrite": {
     "view": {
       "title": "Rewrite Chapter",
+      "close": "Close",
       "originalLabel": "Original ({{count}} segments)",
       "rewrittenLabel": "Rewritten",
       "processing": "Reformulating chapter...",
@@ -112,6 +113,51 @@
     "paragraph": {
       "errorTitle": "Paragraph rewrite failed"
     }
+  },
+  "aiCommandPanel": {
+    "title": "AI Command Panel",
+    "close": "Close AI command panel",
+    "tabs": {
+      "revision": "Revision",
+      "speaker": "Speaker",
+      "merge": "Merge",
+      "chapters": "Chapters"
+    }
+  },
+  "rewriteBatch": {
+    "tabLabel": "Rewrite",
+    "scopeTitle": "Scope",
+    "chaptersCount": "{{count}} chapter",
+    "chaptersCount_plural": "{{count}} chapters",
+    "chaptersCount_one": "{{count}} chapter",
+    "chaptersCount_other": "{{count}} chapters",
+    "skipAlreadyRewritten": "Skip already rewritten chapters",
+    "skipAlreadyRewrittenHelp": "Skip chapters that already have an accepted or pending rewrite",
+    "customInstructions": {
+      "label": "Additional instructions (optional)",
+      "placeholder": "Additional notes to include in the prompt for all chapters"
+    },
+    "batchLogTitle": "Rewrite Log",
+    "batchLogDescription": "Per-chapter batch rewrite status.",
+    "batchLogTriggerLabel": "Rewrite Log",
+    "units": {
+      "chapters": "chapters"
+    },
+    "status": {
+      "pending": "Pending",
+      "processing": "Processing",
+      "done": "Done",
+      "failed": "Failed",
+      "skipped": "Skipped",
+      "cancelled": "Cancelled"
+    },
+    "results": {
+      "draftsTitle": "Drafts ({{count}} pending)"
+    },
+    "errors": {
+      "noChapters": "No chapters to rewrite"
+    },
+    "noChaptersInTranscript": "No chapters in transcript. Add chapters first."
   },
   "import": {
     "transcriptFormatError": "Invalid transcript format",

--- a/docs/features/ai-chapter-rewrite.md
+++ b/docs/features/ai-chapter-rewrite.md
@@ -84,6 +84,20 @@ Configure context settings in **Settings → AI Prompts → Chapters**.
 
 ---
 
+## Batch Rewrite
+
+The Batch Rewrite feature processes all chapters sequentially from top to bottom and creates a pending rewrite draft for each chapter.
+
+Open the AI Command Panel and select the Rewrite tab. Choose provider, model, prompt, optional additional instructions, and whether already rewritten chapters should be skipped.
+
+Processing is intentionally sequential. Each chapter can use the previous chapter's rewritten text as context. If the previous chapter only has a pending draft, that draft is used as context.
+
+Click any item in the Drafts list to open the standard side-by-side review. Accept or reject individually, or use Accept All / Reject All for bulk handling.
+
+Failed chapters can be retried by opening the item and using Regenerate in the review view.
+
+---
+
 ## Editing Rewritten Text
 
 ### In the Review View (Before Accepting)
@@ -261,7 +275,6 @@ Create your own rewrite styles in **Settings → AI Prompts → Chapters**:
 
 ## Coming Soon
 
-- **Batch rewrite**: Process all chapters at once with progress tracking
 - **Style templates**: Import/export custom prompt libraries
 - **Diff view**: Highlight what changed between original and rewritten
 - **Version history**: Keep multiple rewrite versions per chapter

--- a/docs/features/architecture/README.md
+++ b/docs/features/architecture/README.md
@@ -65,6 +65,12 @@ Technical architecture for text revision feature including:
 - UI components and accessibility
 - State management and testing
 
+### Batch Chapter Rewrite
+
+📄 [`batch-rewrite-chapter.md`](./batch-rewrite-chapter.md)
+
+Implementation blueprint for the Rewrite tab in the AI Command Panel, including sequential processing, draft-as-context behavior, cancellation, logging, and UI integration.
+
 ---
 
 ## Core Architecture

--- a/docs/features/architecture/batch-rewrite-chapter.md
+++ b/docs/features/architecture/batch-rewrite-chapter.md
@@ -1,0 +1,627 @@
+# Batch Rewrite Chapter Blueprint
+
+This is the implementation blueprint for adding batch processing to the existing Chapter Rewrite feature. It is intentionally explicit so an implementation agent can follow it without guessing.
+
+## Goal
+
+Add a new **Rewrite** tab to the AI Command Panel. It rewrites all chapters top-to-bottom, creates pending rewrite drafts, shows batch progress and a batch log, supports cancellation, and reuses the existing full-screen `ChapterRewriteView` when clicking a batch item.
+
+The batch must run sequentially. Do not add concurrency. The pending rewrite draft of the previous chapter must be used as context for the next chapter, even if the previous draft has not been accepted yet.
+
+## Existing Files To Reuse
+
+- `client/src/lib/ai/features/rewrite/service.ts`: reuse `rewriteChapter()`.
+- `client/src/lib/store/slices/rewriteSlice.ts`: extend this slice.
+- `client/src/components/rewrite/ChapterRewriteView.tsx`: reuse for side-by-side review.
+- `client/src/components/AICommandPanel/AIBatchControlSection.tsx`: reuse for progress/start/stop.
+- `client/src/components/AICommandPanel/AIConfigurationSection.tsx`: reuse for provider/model/prompt.
+- `client/src/components/AICommandPanel/AIResultsSection.tsx`: reuse for result section.
+- `client/src/components/AICommandPanel/ResultsList.tsx`: reuse for draft item list.
+- `client/src/lib/ai/export/batchLogExport.ts`: extend for rewrite batch log export.
+
+## Non-Goals
+
+- Do not remove or rewrite the existing single-chapter rewrite flow.
+- Do not create a second side-by-side view.
+- Do not add per-chapter custom instructions in the batch UI.
+- Do not add concurrency or a concurrency setting.
+- Do not persist batch processing state.
+
+## Store Changes
+
+### File: `client/src/lib/store/slices/rewriteSlice.ts`
+
+Add these exported types near `RewriteDraft`:
+
+```ts
+export type RewriteBatchItemStatus =
+  | "pending"
+  | "processing"
+  | "done"
+  | "failed"
+  | "skipped"
+  | "cancelled";
+
+export interface RewriteBatchLogEntry {
+  chapterId: string;
+  chapterTitle: string;
+  status: RewriteBatchItemStatus;
+  loggedAt: number;
+  durationMs?: number;
+  error?: string;
+  promptId?: string;
+}
+```
+
+Extend the `RewriteSlice` interface:
+
+```ts
+batchRewriteIsProcessing: boolean;
+batchRewriteIsCancelling: boolean;
+batchRewriteProcessedCount: number;
+batchRewriteTotalCount: number;
+batchRewriteError: string | null;
+batchRewriteAbortController: AbortController | null;
+batchRewriteLog: RewriteBatchLogEntry[];
+
+startBatchRewrite: (options: {
+  promptId: string;
+  customInstructions?: string;
+  skipAlreadyRewritten?: boolean;
+}) => void;
+cancelBatchRewrite: () => void;
+acceptAllBatchRewrites: () => void;
+rejectAllBatchRewrites: () => void;
+```
+
+Extend `initialRewriteState`:
+
+```ts
+batchRewriteIsProcessing: false,
+batchRewriteIsCancelling: false,
+batchRewriteProcessedCount: 0,
+batchRewriteTotalCount: 0,
+batchRewriteError: null,
+batchRewriteAbortController: null,
+batchRewriteLog: [] as RewriteBatchLogEntry[],
+```
+
+Add this import:
+
+```ts
+import { buildSegmentIndexMap, sortChaptersByStart } from "../utils/chapters";
+```
+
+### File: `client/src/lib/store/types.ts`
+
+In `InitialStoreState`, next to the existing rewrite fields, add:
+
+```ts
+batchRewriteIsProcessing: boolean;
+batchRewriteIsCancelling: boolean;
+batchRewriteProcessedCount: number;
+batchRewriteTotalCount: number;
+batchRewriteError: string | null;
+batchRewriteAbortController: AbortController | null;
+batchRewriteLog: import("./slices/rewriteSlice").RewriteBatchLogEntry[];
+```
+
+## `startBatchRewrite` Requirements
+
+Implement `startBatchRewrite` inside `createRewriteSlice`.
+
+Exact behavior:
+
+1. If a previous `batchRewriteAbortController` exists, abort it first.
+2. Find the selected prompt in `state.aiChapterDetectionConfig.prompts` by `promptId`.
+3. If no prompt exists, set `batchRewriteError` to `t("aiBatch.errors.promptNotFound", { id: promptId })` and return.
+4. If the prompt has empty `systemPrompt` or `userPromptTemplate`, set the same error and return.
+5. Sort chapters in document order:
+
+```ts
+const indexMap = buildSegmentIndexMap(state.segments);
+const sortedChapters = sortChaptersByStart(state.chapters, indexMap);
+```
+
+6. If `skipAlreadyRewritten` is true, exclude chapters where either `chapter.rewrittenText` exists or `state.rewriteDraftByChapterId[chapter.id]` exists.
+7. If no chapters remain, set `batchRewriteError` to `t("rewriteBatch.errors.noChapters")` and return.
+8. Create a new `AbortController`.
+9. Set processing state:
+
+```ts
+set({
+  batchRewriteIsProcessing: true,
+  batchRewriteIsCancelling: false,
+  batchRewriteProcessedCount: 0,
+  batchRewriteTotalCount: chaptersToProcess.length,
+  batchRewriteError: null,
+  batchRewriteAbortController: abortController,
+  batchRewriteLog: [],
+});
+```
+
+10. Process chapters with a plain sequential `for` loop. Do not use `Promise.all`, `runConcurrentOrdered`, `runBatchCoordinator`, or any concurrency helper.
+11. Before each request, add a `processing` log entry:
+
+```ts
+const processingEntry: RewriteBatchLogEntry = {
+  chapterId: chapter.id,
+  chapterTitle: chapter.title,
+  status: "processing",
+  loggedAt: Date.now(),
+  promptId,
+};
+```
+
+12. Get chapter segments with `get().selectSegmentsInChapter(chapter.id)`.
+13. If no segments exist, replace the processing log entry with `skipped`, update processed count, and continue.
+14. Before calling `rewriteChapter()`, build a temporary chapter list where pending drafts are exposed as `rewrittenText`:
+
+```ts
+const currentDrafts = get().rewriteDraftByChapterId;
+const allChaptersWithDrafts = get().chapters.map((item) => {
+  const draft = currentDrafts[item.id];
+  return draft?.text ? { ...item, rewrittenText: draft.text } : item;
+});
+```
+
+This is mandatory. `rewriteChapter()` already builds previous-chapter context from `chapter.rewrittenText`. Pending batch drafts are not accepted yet, so the batch must temporarily overlay draft text as `rewrittenText` only for this call.
+
+15. Call `rewriteChapter()` like this:
+
+```ts
+const result = await rewriteChapter({
+  chapter,
+  segments,
+  allChapters: allChaptersWithDrafts,
+  prompt,
+  providerId: get().aiChapterDetectionConfig.selectedProviderId,
+  model: get().aiChapterDetectionConfig.selectedModel,
+  signal: abortController.signal,
+  includeContext: get().aiChapterDetectionConfig.includeContext,
+  contextWordLimit: get().aiChapterDetectionConfig.contextWordLimit,
+  customInstructions,
+});
+```
+
+16. On success, store a draft only:
+
+```ts
+get().setRewriteDraft(chapter.id, {
+  text: result.rewrittenText,
+  promptId,
+  providerId: get().aiChapterDetectionConfig.selectedProviderId,
+  model: get().aiChapterDetectionConfig.selectedModel,
+});
+```
+
+Do not call `setChapterRewrite()` here.
+
+17. Replace the processing log entry with `done`, including `durationMs`, and update `batchRewriteProcessedCount`.
+18. On non-abort errors, replace the processing log entry with `failed`, include `error`, update processed count, and continue with the next chapter.
+19. On `AbortError` or `abortController.signal.aborted`, mark current and remaining chapters as `cancelled`, set processing/cancelling to false, clear the abort controller, and stop.
+20. After the loop finishes, set:
+
+```ts
+set({
+  batchRewriteIsProcessing: false,
+  batchRewriteIsCancelling: false,
+  batchRewriteAbortController: null,
+  batchRewriteError: null,
+});
+```
+
+## Other Store Actions
+
+### `cancelBatchRewrite`
+
+```ts
+cancelBatchRewrite: () => {
+  const state = get();
+  state.batchRewriteAbortController?.abort();
+  set({ batchRewriteIsCancelling: true });
+},
+```
+
+### `acceptAllBatchRewrites`
+
+Iterate over `rewriteDraftByChapterId`. For every existing draft:
+
+```ts
+state.setChapterRewrite(chapterId, draft.text, {
+  promptId: draft.promptId,
+  providerId: draft.providerId,
+  model: draft.model,
+});
+state.clearRewriteDraft(chapterId);
+state.setChapterDisplayMode(chapterId, "rewritten");
+```
+
+### `rejectAllBatchRewrites`
+
+Iterate over `Object.keys(state.rewriteDraftByChapterId)` and call `state.clearRewriteDraft(chapterId)`. Do not call `setChapterRewrite()`.
+
+## Batch Log Export
+
+### File: `client/src/lib/ai/export/batchLogExport.ts`
+
+Extend `BatchLogExportFeatureType`:
+
+```ts
+export type BatchLogExportFeatureType =
+  | "speaker-classification"
+  | "segment-merge"
+  | "chapter-detection"
+  | "revision"
+  | "chapter-rewrite";
+```
+
+Add:
+
+```ts
+import type { RewriteBatchLogEntry } from "@/lib/store/slices/rewriteSlice";
+
+export interface RewriteBatchLogExportRow {
+  chapterId: string;
+  chapterTitle: string;
+  status: string;
+  loggedAt: number;
+  durationMs?: number;
+  error?: string;
+  promptId?: string;
+}
+
+export function mapRewriteBatchLogEntryToExport(
+  entry: RewriteBatchLogEntry,
+): RewriteBatchLogExportRow {
+  return {
+    chapterId: entry.chapterId,
+    chapterTitle: entry.chapterTitle,
+    status: entry.status,
+    loggedAt: entry.loggedAt,
+    durationMs: entry.durationMs,
+    error: entry.error,
+    promptId: entry.promptId,
+  };
+}
+
+export function exportRewriteBatchLog(rows: RewriteBatchLogEntry[], filename: string): void {
+  const payload = buildBatchLogExport("chapter-rewrite", rows.map(mapRewriteBatchLogEntryToExport));
+  downloadAsJson(payload, filename);
+}
+```
+
+## UI: New Rewrite Panel
+
+### New File: `client/src/components/AICommandPanel/RewritePanel.tsx`
+
+Create a new component `RewritePanel` with props:
+
+```ts
+interface RewritePanelProps {
+  onOpenSettings: () => void;
+}
+```
+
+Use these store selectors:
+
+- `chapters`
+- `segments`
+- `aiChapterDetectionConfig`
+- `rewriteDraftByChapterId`
+- `batchRewriteIsProcessing`
+- `batchRewriteIsCancelling`
+- `batchRewriteProcessedCount`
+- `batchRewriteTotalCount`
+- `batchRewriteError`
+- `batchRewriteLog`
+- `startBatchRewrite`
+- `cancelBatchRewrite`
+- `acceptAllBatchRewrites`
+- `rejectAllBatchRewrites`
+
+Use `useAiSettingsSelection()` exactly like `ChapterPanel` does.
+
+Local state:
+
+```ts
+const [selectedPromptId, setSelectedPromptId] = useState(() => rewritePrompts[0]?.id ?? "");
+const [customInstructions, setCustomInstructions] = useState("");
+const [skipAlreadyRewritten, setSkipAlreadyRewritten] = useState(false);
+const [activeViewChapterId, setActiveViewChapterId] = useState<string | null>(null);
+const [isLogOpen, setIsLogOpen] = useState(false);
+```
+
+Prompt options must be:
+
+```ts
+const rewritePrompts = config.prompts.filter((prompt) => prompt.operation === "rewrite");
+```
+
+Chapter order must be:
+
+```ts
+const indexMap = buildSegmentIndexMap(segments);
+const sortedChapters = sortChaptersByStart(chapters, indexMap);
+```
+
+Draft list:
+
+```ts
+const draftsWithChapters = sortedChapters.filter(
+  (chapter) => !!rewriteDraftByChapterId[chapter.id],
+);
+```
+
+Start handler:
+
+```ts
+startBatchRewrite({
+  promptId: selectedPromptId,
+  customInstructions: customInstructions.trim() || undefined,
+  skipAlreadyRewritten,
+});
+```
+
+Render sections in this order:
+
+1. Scope section with chapter count and skip checkbox.
+2. `AIConfigurationSection` with provider/model/prompt only. Do not pass `batchSize` or `onBatchSizeChange`.
+3. `Textarea` for custom instructions.
+4. `AIBatchControlSection` with processed/total counts and stop/start actions.
+5. Batch log drawer or drawer-like inline log with export.
+6. `AIResultsSection` with `ResultsList` for `draftsWithChapters`.
+7. Accept All and Reject All buttons when drafts exist.
+8. Conditional `ChapterRewriteView`:
+
+```tsx
+{activeViewChapterId && (
+  <ChapterRewriteView
+    chapterId={activeViewChapterId}
+    onClose={() => setActiveViewChapterId(null)}
+  />
+)}
+```
+
+Clicking a result item must call `setActiveViewChapterId(chapter.id)`.
+
+## UI: AI Command Panel Tab
+
+### File: `client/src/components/AICommandPanel/AICommandPanel.tsx`
+
+Add import:
+
+```ts
+import { useTranslation } from "react-i18next";
+import { RewritePanel } from "./RewritePanel";
+```
+
+Extend tab type:
+
+```ts
+export type AICommandPanelTab = "revision" | "speaker" | "merge" | "chapters" | "rewrite";
+```
+
+Inside the component:
+
+```ts
+const { t } = useTranslation();
+```
+
+Add tab:
+
+```ts
+{ id: "rewrite", label: t("rewriteBatch.tabLabel") }
+```
+
+Add panel rendering:
+
+```tsx
+{activeTab === "rewrite" && <RewritePanel onOpenSettings={onOpenSettings} />}
+```
+
+While touching this file, replace existing hardcoded user-facing tab labels and panel title/close label with i18n if feasible. At minimum, the new Rewrite tab must use i18n.
+
+## i18n
+
+### File: `client/src/translations/en.json`
+
+Add `rewrite.view.close`:
+
+```json
+"close": "Close"
+```
+
+Add top-level `rewriteBatch`:
+
+```json
+"rewriteBatch": {
+  "tabLabel": "Rewrite",
+  "scopeTitle": "Scope",
+  "chaptersCount": "{{count}} chapter",
+  "chaptersCount_plural": "{{count}} chapters",
+  "skipAlreadyRewritten": "Skip already rewritten chapters",
+  "skipAlreadyRewrittenHelp": "Skip chapters that already have an accepted or pending rewrite",
+  "customInstructions": {
+    "label": "Additional instructions (optional)",
+    "placeholder": "Additional notes to include in the prompt for all chapters"
+  },
+  "batchLogTitle": "Rewrite Log",
+  "batchLogDescription": "Per-chapter batch rewrite status.",
+  "batchLogTriggerLabel": "Rewrite Log",
+  "status": {
+    "pending": "Pending",
+    "processing": "Processing",
+    "done": "Done",
+    "failed": "Failed",
+    "skipped": "Skipped",
+    "cancelled": "Cancelled"
+  },
+  "results": {
+    "draftsTitle": "Drafts ({{count}} pending)"
+  },
+  "errors": {
+    "noChapters": "No chapters to rewrite"
+  },
+  "noChaptersInTranscript": "No chapters in transcript. Add chapters first."
+}
+```
+
+### File: `client/src/translations/de.json`
+
+Add `rewrite.view.close`:
+
+```json
+"close": "Schließen"
+```
+
+Add top-level `rewriteBatch`:
+
+```json
+"rewriteBatch": {
+  "tabLabel": "Rewrite",
+  "scopeTitle": "Bereich",
+  "chaptersCount": "{{count}} Kapitel",
+  "chaptersCount_plural": "{{count}} Kapitel",
+  "skipAlreadyRewritten": "Bereits umgeschriebene Kapitel überspringen",
+  "skipAlreadyRewrittenHelp": "Kapitel überspringen, die bereits einen angenommenen oder ausstehenden Rewrite haben",
+  "customInstructions": {
+    "label": "Zusätzliche Anweisungen (optional)",
+    "placeholder": "Zusätzliche Hinweise für alle Kapitel im Prompt"
+  },
+  "batchLogTitle": "Rewrite-Log",
+  "batchLogDescription": "Status des Batch-Rewrites pro Kapitel.",
+  "batchLogTriggerLabel": "Rewrite-Log",
+  "status": {
+    "pending": "Ausstehend",
+    "processing": "Wird verarbeitet",
+    "done": "Fertig",
+    "failed": "Fehlgeschlagen",
+    "skipped": "Übersprungen",
+    "cancelled": "Abgebrochen"
+  },
+  "results": {
+    "draftsTitle": "Entwürfe ({{count}} ausstehend)"
+  },
+  "errors": {
+    "noChapters": "Keine Kapitel zum Umschreiben vorhanden"
+  },
+  "noChaptersInTranscript": "Kein Kapitel im Transkript vorhanden. Bitte zuerst Kapitel hinzufügen."
+}
+```
+
+### File: `client/src/components/rewrite/ChapterRewriteView.tsx`
+
+Change:
+
+```tsx
+aria-label={t("rewrite.view.close", { defaultValue: "Schließen" })}
+```
+
+to:
+
+```tsx
+aria-label={t("rewrite.view.close")}
+```
+
+## Tests
+
+### New File: `client/src/lib/store/slices/__tests__/rewriteSlice.batch.test.ts`
+
+Base it on `rewriteSlice.test.ts`. Mock the service:
+
+```ts
+vi.mock("@/lib/ai/features/rewrite/service", () => ({
+  rewriteChapter: vi.fn(),
+  rewriteParagraph: vi.fn(),
+}));
+```
+
+Required tests:
+
+- Initial batch state is idle.
+- `startBatchRewrite` processes chapters sequentially and sets drafts.
+- Pending draft from chapter N is passed to chapter N+1 via `allChapters[].rewrittenText`.
+- `skipAlreadyRewritten=true` skips chapters with accepted `rewrittenText`.
+- `skipAlreadyRewritten=true` skips chapters with pending drafts.
+- `skipAlreadyRewritten=false` processes chapters even when they already have `rewrittenText`.
+- A failed chapter is logged as `failed` and the next chapter still runs.
+- Empty chapter segments are logged as `skipped`.
+- After completion, `batchRewriteIsProcessing` is false and `batchRewriteAbortController` is null.
+- `cancelBatchRewrite` aborts the controller and sets `batchRewriteIsCancelling=true`.
+- Abort marks current/remaining chapters as `cancelled`.
+- Invalid prompt sets `batchRewriteError` and does not call `rewriteChapter`.
+- No chapters to process sets `batchRewriteError`.
+- `acceptAllBatchRewrites` calls `setChapterRewrite`, clears drafts, and sets display mode to `rewritten`.
+- `rejectAllBatchRewrites` clears drafts and never calls `setChapterRewrite`.
+
+The most important test is draft-as-context:
+
+```ts
+const chapter2Call = (rewriteChapter as ReturnType<typeof vi.fn>).mock.calls[1][0];
+const previous = chapter2Call.allChapters.find((chapter) => chapter.id === "chapter-1");
+expect(previous.rewrittenText).toBe("Draft text for chapter 1");
+```
+
+### New File: `client/src/components/AICommandPanel/__tests__/RewritePanel.test.tsx`
+
+Base it on `ChapterPanel.test.tsx` and use `renderWithI18n`.
+
+Required tests:
+
+- Shows chapter count.
+- Shows empty-state text when no chapters exist.
+- Start button is disabled when there is no rewrite prompt.
+- Start button is disabled when no chapters can be processed.
+- Clicking Start calls `startBatchRewrite` with `promptId`, `customInstructions`, and `skipAlreadyRewritten`.
+- Checking skip checkbox passes `skipAlreadyRewritten: true`.
+- Draft list appears when `rewriteDraftByChapterId` contains drafts.
+- Clicking a draft item opens `ChapterRewriteView`.
+- Accept All calls `acceptAllBatchRewrites`.
+- Reject All calls `rejectAllBatchRewrites`.
+- Batch log trigger appears when `batchRewriteLog` has entries.
+
+## Documentation Updates
+
+### File: `docs/features/ai-chapter-rewrite.md`
+
+Replace the existing “Coming Soon” batch rewrite note with a real section:
+
+```md
+## Batch Rewrite
+
+The Batch Rewrite feature processes all chapters sequentially from top to bottom and creates a pending rewrite draft for each chapter.
+
+Open the AI Command Panel and select the Rewrite tab. Choose provider, model, prompt, optional additional instructions, and whether already rewritten chapters should be skipped.
+
+Processing is intentionally sequential. Each chapter can use the previous chapter's rewritten text as context. If the previous chapter only has a pending draft, that draft is used as context.
+
+Click any item in the Drafts list to open the standard side-by-side review. Accept or reject individually, or use Accept All / Reject All for bulk handling.
+
+Failed chapters can be retried by opening the item and using Regenerate in the review view.
+```
+
+### File: `docs/features/architecture/README.md`
+
+Add a reference to this document under feature-specific architecture.
+
+## Verification
+
+After implementation, run the full required loop:
+
+```bash
+source ~/.nvm/nvm.sh && nvm use && npm run check
+source ~/.nvm/nvm.sh && nvm use && npm run lint:fix
+source ~/.nvm/nvm.sh && nvm use && npm test
+```
+
+If `lint:fix` changes files, run `npm run check` and `npm test` again.
+
+## Commit Message Suggestion
+
+```text
+feat(rewrite): add batch chapter rewrite blueprint
+
+Documents the batch rewrite architecture, store extensions, UI requirements,
+draft-as-context behavior, test plan, and verification steps.
+```


### PR DESCRIPTION
## Summary
- Add sequential batch chapter rewrite that creates pending drafts and uses prior pending drafts as context.
- Add the AI Command Panel Rewrite tab with scope, prompt/provider/model selection, progress, logs, draft review, and bulk accept/reject.
- Add rewrite batch log export, i18n entries, tests, and documentation.
- Add repo-local Node 24 direnv setup via .envrc.

## Plan
1. Extend rewrite store state and actions for sequential batch processing, cancellation, logging, and draft bulk actions.
2. Reuse existing rewrite service and overlay pending drafts as temporary rewritten chapter context for the next request.
3. Add the Rewrite panel UI using existing AI command panel building blocks.
4. Reuse the existing ChapterRewriteView for draft review without clearing drafts on close.
5. Add rewrite-specific batch log export and wire it through the existing drawer.
6. Cover store and UI behavior with tests, including cancellation races and draft-as-context behavior.
7. Document the batch rewrite workflow and architecture entry point.

## Verification
- source ~/.nvm/nvm.sh && nvm use && npm run check
- source ~/.nvm/nvm.sh && nvm use && npm run lint:fix
- source ~/.nvm/nvm.sh && nvm use && npm test

Latest full test run: 168 files passed, 1607 tests passed.